### PR TITLE
CMR7 WiFi netcode redesign: free-running lockstep (stages 0r-4) + v3.1.0

### DIFF
--- a/Source/Headers/main.h
+++ b/Source/Headers/main.h
@@ -110,4 +110,5 @@ void GameMain(void);
 void ToolBoxInit(void);
 void FadeOutArea(void);
 void MoveEverything(void);
+void UpdateGameModeSpecifics(void);		// CMR7: shared by Main.c game loop and the client pause-menu lockstep
 void InitDefaultPrefs(void);

--- a/Source/Headers/netsprocket.h
+++ b/Source/Headers/netsprocket.h
@@ -171,6 +171,7 @@ int NSpGame_StopAdvertising(NSpGameReference gameRef);
 int NSpGame_AdvertiseTick(NSpGameReference gameRef, float dt);
 bool NSpGame_IsAdvertising(NSpGameReference gameRef);
 int NSpGame_Dispose(NSpGameReference inGame, int disposeFlags);
+void NSpGame_FlushSends(NSpGameReference gameRef);
 
 NSpSearchReference NSpSearch_StartSearchingForGameHosts(void);
 int NSpSearch_Dispose(NSpSearchReference searchRef);

--- a/Source/Headers/netsprocket.h
+++ b/Source/Headers/netsprocket.h
@@ -18,10 +18,10 @@ typedef int sockfd_t;
 
 #define MAX_CLIENTS MAX_LOCAL_PLAYERS
 #define kNSpPlayerNameLength 32
-#define kNSpMaxPayloadLength 256
+#define kNSpMaxPayloadLength 512			// CMR7: bumped 256->512 to fit the wider host control msg (must change with the 4CC)
 #define kNSpMaxMessageLength (kNSpMaxPayloadLength + sizeof(NSpMessageHeader))
 
-#define kNSpCMRProtocol4CC 'CMR6'
+#define kNSpCMRProtocol4CC 'CMR7'			// CMR7 wire format; old 'CMR6' peers are cleanly rejected by the version check
 
 typedef enum
 {

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -32,7 +32,7 @@ typedef struct
 	//	uint8_t				numTracksCompleted;					// pass saved game value to clients so we're all the same here
 	uint8_t				difficulty;							// pass host's difficulty setting so we're in sync
 	uint8_t				tagDuration;						// # minutes in tag game
-	uint8_t				useRedundancy;						// Enable redundant input transmission (WiFi mode)
+	uint8_t				reserved;							// CMR7: was useRedundancy (retired; per-client adaptive depth replaces it)
 	uint16_t			targetFPS;							// The FPS cap for the game (min of all players)
 }NetConfigMessage;
 
@@ -41,45 +41,70 @@ typedef struct
 typedef struct
 {
 	NSpMessageHeader	h;
+	uint16_t			targetFPS;							// CMR7: host-finalized FPS (written/read in Stage 4)
+	uint16_t			pad;
 }NetSyncMessage;
+_Static_assert(sizeof(NetSyncMessage) <= kNSpMaxMessageLength, "sync msg fits");
 
 
-		/* HOST CONTROL INFO MESSAGE */
+		/* FRAME-ALIGNED GAME EVENT (CMR7) */
+		//
+		// Carried in the host control stream so every machine applies a leave/bot-conversion
+		// at the identical sim frame. Fields land in the CMR7 bump; populated in Stage 4.
+		//
+
+enum { kEvReserved = 0, kEvBecomeBot = 1, kEvUnpauseForce = 2 };
+enum { INPUT_FLAG_SUBSTITUTED = 0x01, INPUT_FLAG_COALESCED = 0x02 };
+
+typedef struct
+{
+	uint32_t			effectiveFrame;					// host sim frame at which every machine applies it
+	uint8_t				type;							// kEv*
+	int8_t				playerNum;
+	uint16_t			pad;
+}NetFrameEvent;
+_Static_assert(sizeof(NetFrameEvent) == 8, "NetFrameEvent ABI");
+
+
+		/* HOST CONTROL INFO MESSAGE (CMR7) */
 
 typedef struct
 {
 	NSpMessageHeader	h;
 	float				fps, fpsFrac;
-	uint32_t			randomSeed;					// simply used for error checking (all machines should have same seed!)
+	uint32_t			randomSeed;						// simply used for error checking (all machines should have same seed!)
+	uint32_t			frameCounter;					// host frame (gHostSendCounter)
+	uint32_t			simTick;						// gSimulationFrame (diagnostic)
 	uint32_t			controlBits[MAX_PLAYERS];
-	uint32_t			controlBitsNew[MAX_PLAYERS];
+	uint32_t			controlBitsNew[MAX_PLAYERS];	// HOST-DERIVED edges (clients apply verbatim)
 	OGLVector2D			analogSteering[MAX_PLAYERS];
-	uint32_t			frameCounter;
-	uint8_t				pauseState[MAX_PLAYERS];
-
-	uint32_t			simTick;
-	OGLPoint3D			syncPos[MAX_PLAYERS];			// Authoritative position from Host
+	OGLPoint3D			syncPos[MAX_PLAYERS];			// Authoritative position from Host (rubber-band feed)
 	float				syncRotY[MAX_PLAYERS];			// Authoritative Y-Rotation (Heading)
+	uint32_t			ackInputSeq[MAX_PLAYERS];		// last REAL input seq applied per player
+	uint8_t				pauseState[MAX_PLAYERS];
+	uint8_t				inputFlags[MAX_PLAYERS];		// bit0 substituted, bit1 coalesced (telemetry)
+	uint8_t				queueDepth[MAX_PLAYERS];		// telemetry
+	uint8_t				targetDepth[MAX_PLAYERS];		// telemetry
+	uint8_t				eventCount;						// 0..2 (0 until Stage 4)
+	NetFrameEvent		events[2];
 }NetHostControlInfoMessageType;
+_Static_assert(sizeof(NetHostControlInfoMessageType) <= kNSpMaxMessageLength, "host msg fits");
 
 
-		/* CLIENT CONTROL INFO MESSAGE */
+		/* CLIENT CONTROL INFO MESSAGE (CMR7) */
 
 typedef struct
 {
 	NSpMessageHeader	h;
 	int16_t				playerNum;
-	uint32_t			controlBits;
-	uint32_t			controlBitsNew;
-	uint32_t			frameCounter;
-	OGLVector2D			analogSteering;
-
-	// Redundancy History (Last 8 frames)
-	uint32_t			prevControlBits[8];
-	OGLVector2D			prevAnalogSteering[8];
-	
 	uint8_t				pauseState;
+	uint8_t				pad;
+	uint32_t			inputSeq;						// monotonic, client-owned (was frameCounter)
+	uint32_t			lastHostFrameSeen;				// RTT/diagnostics
+	uint32_t			controlBits;
+	OGLVector2D			analogSteering;
 }NetClientControlInfoMessageType;
+_Static_assert(sizeof(NetClientControlInfoMessageType) <= kNSpMaxMessageLength, "client msg fits");
 
 
 		/* PLAYER CHAR TYPE MESSAGE */
@@ -110,9 +135,15 @@ void HostSend_ControlInfoToClients(void);
 void ClientSend_ControlInfoToHost(void);
 void ClientReceive_ControlInfoFromHost(void);
 Boolean Client_CheckIfMorePacketsWaiting(void);
-void HostReceive_ControlInfoFromClients(void);
+
+void Host_PumpClientInputs(void);				// CMR7: non-blocking drain of client inputs into per-player queues
+void Host_ConsumeClientInputs(void);			// CMR7: depth controller + substitution + coalesce + single-apply
+void Host_InitInputControl(void);				// CMR7: seed per-client D_init before the game loop
+void SampleAndSendLocalInput(Boolean* outSchedulePause);	// CMR7: wall-clock-paced client input sampler
+void ResetNetGameTransientState(void);			// CMR7: zero all per-session host/client net state
 
 void Net_Pump(void);
+int Net_GetConnectionHint(void);				// CMR7: per-client D_init seed (1 = WiFi, 0 = wired)
 
 void PlayerBroadcastVehicleType(void);
 Boolean GetVehicleSelectionFromNetPlayers(void);

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -123,6 +123,14 @@ typedef struct
 
 //===============================================================================
 
+// CMR7 Stage 3: result of consuming one staged host control packet from the client ring.
+typedef enum
+{
+	kHostConsume_Empty		= 0,			// ring empty
+	kHostConsume_Dup		= 1,			// popped but the handler dropped it (old/dup) — no sim step
+	kHostConsume_Applied	= 2,			// popped + applied (counter advanced) — caller steps the sim
+} HostConsumeResult;
+
 
 void InitNetworkManager(void);
 void ShutdownNetworkManager(void);
@@ -133,8 +141,11 @@ void HostWaitForPlayersToPrepareLevel(void);
 
 void HostSend_ControlInfoToClients(void);
 void ClientSend_ControlInfoToHost(void);
-void ClientReceive_ControlInfoFromHost(void);
-Boolean Client_CheckIfMorePacketsWaiting(void);
+void ClientReceive_ControlInfoFromHost(void);	// CMR7 Stage 3: retained bounded shim — Paused.c / loading barriers only
+void Client_PumpHostPackets(void);				// CMR7 Stage 3: non-blocking drain of host control packets into the client ring
+HostConsumeResult Client_ConsumeHostPacketFromRing(void);	// CMR7 Stage 3: pop one + apply via the verbatim handler
+Boolean Client_IsHoldBadgeVisible(void);		// CMR7 Stage 3: subtle net badge after ~250ms of host-packet absence
+void ResetClientHostRing(void);					// CMR7 Stage 3: clear the client host-packet ring between net games
 
 void Host_PumpClientInputs(void);				// CMR7: non-blocking drain of client inputs into per-player queues
 void Host_ConsumeClientInputs(void);			// CMR7: depth controller + substitution + coalesce + single-apply

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -112,6 +112,8 @@ void ClientReceive_ControlInfoFromHost(void);
 Boolean Client_CheckIfMorePacketsWaiting(void);
 void HostReceive_ControlInfoFromClients(void);
 
+void Net_Pump(void);
+
 void PlayerBroadcastVehicleType(void);
 Boolean GetVehicleSelectionFromNetPlayers(void);
 

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -113,7 +113,7 @@ Boolean Client_CheckIfMorePacketsWaiting(void);
 void HostReceive_ControlInfoFromClients(void);
 
 void PlayerBroadcastVehicleType(void);
-void GetVehicleSelectionFromNetPlayers(void);
+Boolean GetVehicleSelectionFromNetPlayers(void);
 
 
 void EndNetworkGame(void);

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -35,6 +35,7 @@ typedef struct
 	uint8_t				reserved;							// CMR7: was useRedundancy (retired; per-client adaptive depth replaces it)
 	uint16_t			targetFPS;							// The FPS cap for the game (min of all players)
 }NetConfigMessage;
+_Static_assert(sizeof(NetConfigMessage) <= kNSpMaxMessageLength, "config msg fits");
 
 		/* SYNC MESSAGE */
 
@@ -119,6 +120,7 @@ typedef struct
 	int16_t				refreshRate;						// Client's monitor refresh rate
 	int16_t				connectionType;						// 0 = Wired, 1 = WiFi
 }NetPlayerCharTypeMessage;
+_Static_assert(sizeof(NetPlayerCharTypeMessage) <= kNSpMaxMessageLength, "char-type msg fits");
 
 
 //===============================================================================

--- a/Source/Items/Items.c
+++ b/Source/Items/Items.c
@@ -832,10 +832,22 @@ Boolean AddStump(TerrainItemEntryType *itemPtr, long  x, long z)
 {
 ObjNode	*newObj;
 
+	// Stumps are solid/collidable (CBITS_ALLSOLID + collision box built from the mesh bbox
+	// below), so the mesh index changes collision geometry -> sim-affecting. Derive the variant
+	// from a PURE, frame-independent hash of the world coords only. ChaoticFloat must NOT be used
+	// here: it folds in gSimulationFrame, and stumps stream in at peer-divergent frames (terrain
+	// streaming is driven by each machine's LOCAL camera position), so routing the persistent
+	// collision variant through it would desync the collision box across peers.
+	uint32_t h = ((uint32_t)x * 73856093u) ^ ((uint32_t)z * 19349663u);
+	h ^= h >> 13;
+	h *= 0xc2b2ae35u;
+	h ^= h >> 16;
+
 	NewObjectDefinitionType def =
 	{
 		.group 		= MODEL_GROUP_LEVELSPECIFIC,
-		.type 		= SCANDINAVIA_ObjType_Stump1 + (VisualRandomLong() & 0x3),
+		// The .rot below stays on VisualRandom (purely visual).
+		.type 		= SCANDINAVIA_ObjType_Stump1 + (h & 0x3),
 		.coord		= {x,0,z},
 		.flags 		= gAutoFadeStatusBits,
 		.slot 		= 400,

--- a/Source/Items/Traps.c
+++ b/Source/Items/Traps.c
@@ -724,12 +724,15 @@ float			speed;
 			/* SET IN MOTION */
 			/*****************/
 
-		speed = 8000.0f + VisualRandomFloat() * 1000.0f;
+		// The thrown rock's trajectory is collision-relevant (rocks can hit cars), so key the
+		// launch speed/heading/Delta.y on the catapult's heading via stateless ChaoticFloat
+		// (unique per-rock/per-draw modifier) instead of the unsynced VisualRandom stream.
+		speed = 8000.0f + ChaoticFloat(theNode->Rot.y, i*3 + 0) * 1000.0f;
 
-		OGLMatrix4x4_SetRotate_Y(&m, theNode->Rot.y + (VisualRandomFloat2() * .3f));
+		OGLMatrix4x4_SetRotate_Y(&m, theNode->Rot.y + (ChaoticFloat(theNode->Rot.y, i*3 + 1) - 0.5f) * 2.0f * .3f);
 		OGLVector3D_Transform(&throwVector,	&m, &newObj->Delta);
 
-		newObj->Delta.y += VisualRandomFloat() * .1f;
+		newObj->Delta.y += ChaoticFloat(theNode->Rot.y, i*3 + 2) * .1f;
 
 		newObj->Delta.x *= speed;															// give it speed
 		newObj->Delta.y *= speed;
@@ -945,9 +948,12 @@ OGLPoint3D			pt;
 
 		/* CALC VECTOR FROM GODDESS TO PLAYER */
 
-	boltVector.x = (gPlayerInfo[playerNum].coord.x + VisualRandomFloat2() * 300.0f) - x;
+	// The targeting offset decides WHERE the bolt strikes (damage gating) -> sim-affecting,
+	// so key it on the target player's coord + slot via stateless ChaoticFloat. The bolt-path
+	// jaggedness endpoints below stay on VisualRandom (pure visual).
+	boltVector.x = (gPlayerInfo[playerNum].coord.x + (ChaoticFloat(gPlayerInfo[playerNum].coord.x, playerNum) - 0.5f) * 2.0f * 300.0f) - x;
 	boltVector.y = gPlayerInfo[playerNum].coord.y - y;
-	boltVector.z = (gPlayerInfo[playerNum].coord.z + VisualRandomFloat2() * 300.0f) - z;
+	boltVector.z = (gPlayerInfo[playerNum].coord.z + (ChaoticFloat(gPlayerInfo[playerNum].coord.z, playerNum + 5) - 0.5f) * 2.0f * 300.0f) - z;
 
 	boltVector.x /= (float)(numSegments-1);							// divide vector length for multiple segments
 	boltVector.y /= (float)(numSegments-1);
@@ -1188,10 +1194,12 @@ NewParticleDefType		newParticleDef;
 
 	speed = dist * .9f;
 
-	OGLMatrix4x4_SetRotate_Y(&m2, theNode->Rot.y + (VisualRandomFloat2() * .1f));
+	// The cannonball's trajectory is collision-relevant, so key the launch jitter on the
+	// cannon's heading via stateless ChaoticFloat instead of the unsynced VisualRandom stream.
+	OGLMatrix4x4_SetRotate_Y(&m2, theNode->Rot.y + (ChaoticFloat(theNode->Rot.y, 0) - 0.5f) * 2.0f * .1f);
 	OGLVector3D_Transform(&throwVector,	&m2, &delta);
 
-	newObj->Delta.y += VisualRandomFloat() * .1f;
+	newObj->Delta.y += ChaoticFloat(theNode->Rot.y, 1) * .1f;
 
 	newObj->Delta.x = delta.x * speed;															// give it speed
 	newObj->Delta.y = delta.y * speed;
@@ -1490,9 +1498,12 @@ OGLPoint3D			pt;
 
 		/* CALC VECTOR FROM CAPSULE TO PLAYER */
 
-	boltVector.x = (gPlayerInfo[playerNum].coord.x + VisualRandomFloat2() * 300.0f) - x;
+	// The targeting offset decides WHERE the bolt strikes (damage gating) -> sim-affecting,
+	// so key it on the target player's coord + slot via stateless ChaoticFloat. The bolt-path
+	// jaggedness endpoints below stay on VisualRandom (pure visual).
+	boltVector.x = (gPlayerInfo[playerNum].coord.x + (ChaoticFloat(gPlayerInfo[playerNum].coord.x, playerNum) - 0.5f) * 2.0f * 300.0f) - x;
 	boltVector.y = gPlayerInfo[playerNum].coord.y - y;
-	boltVector.z = (gPlayerInfo[playerNum].coord.z + VisualRandomFloat2() * 300.0f) - z;
+	boltVector.z = (gPlayerInfo[playerNum].coord.z + (ChaoticFloat(gPlayerInfo[playerNum].coord.z, playerNum + 5) - 0.5f) * 2.0f * 300.0f) - z;
 
 	boltVector.x /= (float)(numSegments-1);							// divide vector length for multiple segments
 	boltVector.y /= (float)(numSegments-1);

--- a/Source/Items/Triggers.c
+++ b/Source/Items/Triggers.c
@@ -1438,8 +1438,10 @@ short	teamNum;
 
 			/* PUT TORCH ON BASE */
 
-	theTorch->Coord.x = theNode->Coord.x + VisualRandomFloat2() * 100.0f;
-	theTorch->Coord.z = theNode->Coord.z + VisualRandomFloat2() * 100.0f;
+	// The captured-torch placement sets capture/scoring geometry -> sim-affecting, so key it on
+	// the base coord + team via stateless ChaoticFloat instead of the unsynced VisualRandom stream.
+	theTorch->Coord.x = theNode->Coord.x + (ChaoticFloat(theNode->Coord.x, teamNum) - 0.5f) * 2.0f * 100.0f;
+	theTorch->Coord.z = theNode->Coord.z + (ChaoticFloat(theNode->Coord.z, teamNum + 1) - 0.5f) * 2.0f * 100.0f;
 	theTorch->Coord.y = theNode->Coord.y + gObjectGroupBBoxList[MODEL_GROUP_GLOBAL][GLOBAL_ObjType_TeamBaseRed].max.y;
 
 	UpdateObjectTransforms(theTorch);

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -595,6 +595,8 @@ NetConfigMessage		message;
 
 	gNumRealPlayers = NSpGame_GetNumActivePlayers(gNetGame);
 
+	gNumGatheredPlayers = gNumRealPlayers;							// live human count; decremented as players leave (drives the everybody-left check)
+
 	gMyNetworkPlayerNum = 0;										// the host is always player #0
 
 
@@ -674,6 +676,8 @@ void HandleGameConfigMessage(NetConfigMessage* inMessage)
 		gNumRealPlayers = MAX_PLAYERS;
 	if (!IsValidPlayerNum(gMyNetworkPlayerNum))
 		gMyNetworkPlayerNum = 0;
+
+	gNumGatheredPlayers = gNumRealPlayers;					// live human count; decremented as players leave (drives the everybody-left check)
 
 	gDifficulty			= inMessage->difficulty;
 	gTagDuration		= inMessage->tagDuration;
@@ -1235,9 +1239,19 @@ Boolean								abort = false;
 	while (!AreAllPlayersSynced() && !abort)				// loop until I've got the message from all players
 	{
 		// 1. Process Queues (Buffers)
+		//
+		// The sync mask is keyed on NSp slot IDs (AreAllPlayersSynced compares against
+		// NSpGame_GetActivePlayersIDMask), but the queues/counters are indexed by internal
+		// playerNum. Mark/check the mask by gPlayerInfo[i].net.nspPlayerID, keep the queue and
+		// counter access playerNum-based, and skip bots (no live NSp ID, never in the target
+		// mask) so lobby churn (e.g. IDs {0,2} / playerNums {0,1}) can't wedge the barrier.
 		for (int i = 0; i < gNumRealPlayers; i++)
 		{
-			if (PlayerIsSynced(i)) continue; // Already have data for this frame
+			if (gPlayerInfo[i].isComputer) continue;	// bots have no NSp ID, not in target mask
+
+			NSpPlayerID id = gPlayerInfo[i].net.nspPlayerID;
+
+			if (PlayerIsSynced(id)) continue; // Already have data for this frame
 
 			NetClientControlInfoMessageType* msg = Queue_Peek(i);
 			while (msg)
@@ -1253,7 +1267,7 @@ Boolean								abort = false;
 					// Exact Match
 					ApplyClientMessage(msg);
 					gClientSendCounter[i]++;
-					MarkPlayerSynced(i);
+					MarkPlayerSynced(id);
 					Queue_Pop(i);
 					break; // Done for this player
 				}
@@ -1263,7 +1277,7 @@ Boolean								abort = false;
 					if (RecoverFromFuture(msg, gClientSendCounter[i]))
 					{
 						gClientSendCounter[i]++;
-						MarkPlayerSynced(i);
+						MarkPlayerSynced(id);
 						// Do NOT Pop. Keep future packet for later.
 					}
 					break; // Wait for missing packets (or used recovery)
@@ -1463,13 +1477,16 @@ NetPlayerCharTypeMessage	outMess;
 
 /***************** GET VEHICLE SELECTION FROM NET PLAYERS ***********************/
 
-void GetVehicleSelectionFromNetPlayers(void)
+// Returns true if the player aborted or the net game was torn down while waiting for the
+// other players' vehicle selections, so the caller can bail cleanly instead of starting a
+// broken match.
+Boolean GetVehicleSelectionFromNetPlayers(void)
 {
 	ClearPlayerSyncMask();
 	MarkPlayerSynced(NSpPlayer_GetMyID(gNetGame));		// we have our own local info already
 
 	gNetSequenceState = kNetSequence_WaitingForPlayerVehicles;
-	DoNetGatherScreen();
+	return DoNetGatherScreen();							// true == aborted/torn down
 }
 
 
@@ -1588,7 +1605,10 @@ NSpPlayerID	playerID = mess->playerID;
 	gNumGatheredPlayers--;										// one less net player in the game
 	// gNumRealPlayers--;										// DON'T decrement this, or the screen layout will change mid-game!
 
-	if (gNumRealPlayers <= 1)									// see if nobody to play with
+	// Use gNumGatheredPlayers (the live human count, decremented above) here, NOT gNumRealPlayers
+	// which is intentionally never decremented to keep the split-screen layout stable. Checking
+	// gNumRealPlayers meant gGameOver never fired when everyone else bailed.
+	if (gNumGatheredPlayers <= 1)								// see if nobody to play with
 		gGameOver = true;
 
 			/* HANDLE SPECIFICS */

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -1210,12 +1210,18 @@ void Client_PumpHostPackets(void)
 
 		if (inMess->what == kNetHostControlInfoMessage)
 		{
-			HostRing_PushControl((NetHostControlInfoMessageType*) inMess);	// guaranteed space (ring not full)
-			sLastHostArrivalTick = TickCount();								// arrival time for the hold badge
+			if (inMess->messageLen >= sizeof(NetHostControlInfoMessageType))		// don't copy a short message up to the full struct (mirror the host-side guard)
+			{
+				HostRing_PushControl((NetHostControlInfoMessageType*) inMess);	// guaranteed space (ring not full)
+				sLastHostArrivalTick = TickCount();								// arrival time for the hold badge
+			}
+			// else: malformed/short control frame — drop it (released below)
 		}
 		else if (inMess->what == kNSpGameTerminated)
 		{
 			HandleOtherNetMessage(inMess);						// teardown only (no gSimRNG / sim-set touch): act now
+			NSpMessage_Release(gNetGame, inMess);				// release before the loop reuses gNetGame (now nil after teardown)
+			break;												// session torn down — stop draining
 		}
 		else
 		{
@@ -1532,7 +1538,7 @@ void Host_ConsumeClientInputs(void)
 				/* DISCARD STALE PACKETS (dups / already-consumed pre-roll) */
 
 		NetClientControlInfoMessageType* p;
-		while ((p = Queue_Peek(i)) != NULL && p->inputSeq <= S->lastAppliedSeq)
+		while ((p = Queue_Peek(i)) != NULL && S->valid && p->inputSeq <= S->lastAppliedSeq)	// S->valid guard: don't discard the very first packet (inputSeq 0) before any real input is applied
 			Queue_Pop(i);
 
 		int B = Queue_Count(i);

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -15,6 +15,7 @@
 #include "miscscreens.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include <SDL3/SDL.h>
 
 #if defined(__APPLE__) && !defined(__IOS__) && !defined(__TVOS__)
@@ -67,8 +68,6 @@ uint32_t			gClientSendCounter[MAX_PLAYERS];
 uint32_t			gHostSendCounter;
 int				gTimeoutCounter;
 
-static void ResetNetGameTransientState(void);		// defined below, near the host input queues
-
 NetHostControlInfoMessageType	gHostOutMess;
 NetClientControlInfoMessageType	gClientOutMess;
 
@@ -88,7 +87,10 @@ void Net_Pump(void)
 	if (!gNetGameInProgress || gNetGame == nil)
 		return;
 
-	NSpGame_FlushSends(gNetGame);
+	NSpGame_FlushSends(gNetGame);			// Stage 1: drain non-blocking send rings
+
+	if (gIsNetworkHost)
+		Host_PumpClientInputs();			// CMR7: non-blocking drain of client inputs into per-player queues
 }
 
 
@@ -137,18 +139,129 @@ static void MarkPlayerSynced(NSpPlayerID playerID)
 	gPlayerSyncMask |= 1 << playerID;
 }
 
-static Boolean PlayerIsSynced(NSpPlayerID playerID)
-{
-	if (playerID < 0 || playerID >= 32)
-		return false;
-	return (gPlayerSyncMask & (1 << playerID)) != 0;
-}
+// (PlayerIsSynced was only used by the deleted HostReceive busy-spin; the lobby/level-prep
+// barriers use MarkPlayerSynced + AreAllPlayersSynced, so it is no longer needed.)
 
 static Boolean AreAllPlayersSynced(void)
 
 {
 	uint32_t targetMask = NSpGame_GetActivePlayersIDMask(gNetGame);
 	return 0 == (gPlayerSyncMask ^ targetMask);
+}
+
+
+#pragma mark - Host input control state (CMR7)
+
+//
+// CMR7 host-side input control. The host NEVER blocks on a client's radio: client input
+// packets are drained (non-blocking) into per-client queues by Host_PumpClientInputs, then
+// resolved each host frame by Host_ConsumeClientInputs, which SUBSTITUTES held input on an
+// underrun and COALESCES a backlog down to the per-client adaptive depth D_i. Edge bits
+// (controlBits_New) are derived host-side with the engine's own formula. This replaces the
+// old blocking, 4-strike HostReceive busy-spin.
+//
+
+#define NET_QUEUE_SIZE		128					// ~2s of client inputs @60fps (was 64)
+#define JITTER_WINDOW		128					// inter-arrival samples kept for the depth controller
+#define GRACE_RETRIES		2					// bounded re-poll attempts (~1ms each) before substituting
+#define SUB_DECAY_AFTER		30					// consecutive substituted frames before neutral decay
+#define MAX_SAMPLE_BURST	3					// wall-clock sampler max packets emitted per call
+
+typedef struct {
+	int head;
+	int tail;
+	NetClientControlInfoMessageType msgs[NET_QUEUE_SIZE];
+} PacketQueue;
+
+static PacketQueue sHostInputQueues[MAX_PLAYERS];
+
+// Last REAL input applied per client: edge-derivation baseline + ack source. NOT decayed.
+typedef struct {
+	uint32_t	controlBits;		// last REAL bits (edge baseline; never touched by decay)
+	OGLVector2D	analogSteering;		// last REAL analog (held while substituting)
+	uint8_t		pauseState;			// last REAL pause (HELD on substitute -> never spurious unpause)
+	uint32_t	lastAppliedSeq;		// == ackInputSeq broadcast; stale rule: seq <= this -> discard
+	Boolean		valid;				// false until first real input applied this race
+	uint16_t	subStreak;			// consecutive substituted frames
+} HostClientInputState;
+static HostClientInputState sLastApplied[MAX_PLAYERS];
+
+// Per-client adaptive input-queue depth controller (sized from measured arrival jitter).
+typedef struct {
+	uint64_t	lastArrivalPC;			// SDL_GetPerformanceCounter of previous packet (0=none)
+	float		deltas[JITTER_WINDOW];	// inter-arrival deltas (seconds)
+	int			count, head;			// ring fill / write idx
+	uint8_t		targetDepth;			// D_i, seeded D_init, clamp [1,8]
+	float		decayAccumSec;			// accumulator for 1-frame-per-2s decay
+	double		baselineSec;			// perf-time of last P95 recompute (throttle to <=4Hz)
+	uint8_t		baselineDepth;			// live P95-derived baseline depth (decay floor)
+} HostClientDepthState;
+static HostClientDepthState sDepth[MAX_PLAYERS];
+
+static uint8_t sInputFlags[MAX_PLAYERS];			// rebuilt each consume frame (telemetry)
+static uint8_t sClientConnectionHint[MAX_PLAYERS];	// 0 wired / 1 wifi, from char-type msg
+
+static double sNextSampleTime = 0.0;				// wall-clock sampler cursor (seconds, perf-counter base)
+
+
+static void Queue_Push(int playerNum, NetClientControlInfoMessageType* msg)
+{
+	if (!IsValidPlayerNum(playerNum)) return;		// never index sHostInputQueues[] with an out-of-range wire value
+	PacketQueue* q = &sHostInputQueues[playerNum];
+	int next = (q->tail + 1) % NET_QUEUE_SIZE;
+	if (next != q->head)							// drop on full ring (>~2s backlog = deep underrun)
+	{
+		q->msgs[q->tail] = *msg;
+		q->tail = next;
+	}
+}
+
+static NetClientControlInfoMessageType* Queue_Peek(int playerNum)
+{
+	if (!IsValidPlayerNum(playerNum)) return NULL;
+	PacketQueue* q = &sHostInputQueues[playerNum];
+	if (q->head == q->tail) return NULL;
+	return &q->msgs[q->head];
+}
+
+static void Queue_Pop(int playerNum)
+{
+	if (!IsValidPlayerNum(playerNum)) return;
+	PacketQueue* q = &sHostInputQueues[playerNum];
+	if (q->head != q->tail)
+		q->head = (q->head + 1) % NET_QUEUE_SIZE;
+}
+
+static int Queue_Count(int playerNum)
+{
+	if (!IsValidPlayerNum(playerNum)) return 0;
+	PacketQueue* q = &sHostInputQueues[playerNum];
+	int n = q->tail - q->head;
+	if (n < 0) n += NET_QUEUE_SIZE;
+	return n;
+}
+
+// Engine edge-derivation formula (InputControlBits.c:145): newly-pressed bits this step.
+static inline uint32_t Host_DeriveEdges(uint32_t prevBits, uint32_t newBits)
+{
+	return (newBits ^ prevBits) & newBits;
+}
+
+// Clear ALL per-process net state that must NOT survive from one net game to the next.
+// Called from both setup paths and EndNetworkGame so stale state can never wedge a later
+// game (queues holding future seqs, depth/substitution bookkeeping, the stall-strike
+// counter, the send counters, and the wall-clock sampler cursor all used to persist).
+void ResetNetGameTransientState(void)
+{
+	memset(sHostInputQueues, 0, sizeof(sHostInputQueues));
+	memset(sLastApplied, 0, sizeof(sLastApplied));
+	memset(sDepth, 0, sizeof(sDepth));
+	memset(sInputFlags, 0, sizeof(sInputFlags));
+	memset(sClientConnectionHint, 0, sizeof(sClientConnectionHint));
+	gTimeoutCounter = 0;
+	gHostSendCounter = 0;
+	memset(gClientSendCounter, 0, sizeof(gClientSendCounter));
+	sNextSampleTime = 0.0;
 }
 
 
@@ -251,9 +364,7 @@ OSErr	iErr;
 		gNetSequenceState	= kNetSequence_Offline;
 	ClearPlayerSyncMask();
 	gSimulationPaused	= false;
-	gHostSendCounter	= 0;
-	memset(gClientSendCounter, 0, sizeof(gClientSendCounter));
-	ResetNetGameTransientState();			// clear host input queues, redundancy history, stall-strike counter
+	ResetNetGameTransientState();			// clear host input queues, depth/substitution state, counters, stall-strike counter
 }
 
 
@@ -423,12 +534,11 @@ bool UpdateNetSequence(void)
 							printf("New client joined with %dHz. Lowering TargetFPS to %d.\n", mess->refreshRate, gTargetFPS);
 						}
 
-						// Check for WiFi / Redundancy
+						// CMR7: record this client's WiFi/wired hint as a per-client adaptive-depth seed
+						// (replaces the old global gUseRedundancy all-or-nothing switch).
+						sClientConnectionHint[mess->playerNum] = (mess->connectionType == 1) ? 1 : 0;
 						if (mess->connectionType == 1)
-						{
-							gUseRedundancy = true;
-							printf("New client is on WiFi. Enabling Redundant Input Mode.\n");
-						}
+							printf("New client %d is on WiFi. Seeding deeper input queue.\n", mess->playerNum);
 
 						MarkPlayerSynced(message->from);								// inc count of received info
 
@@ -511,8 +621,8 @@ Boolean SetupNetworkHosting(void)
 	ResetNetGameTransientState();			// start from a clean slate (belt-and-suspenders vs EndNetworkGame)
 	gNetSequenceState = kNetSequence_HostOffline;
 	gTargetFPS = OGL_GetMonitorRefreshRate();
-	gUseRedundancy = (Net_GetConnectionHint() == 1);
-	printf("Hosting Game. Local Refresh Rate: %dHz, WiFi: %d\n", gTargetFPS, gUseRedundancy);
+	sClientConnectionHint[0] = (Net_GetConnectionHint() == 1) ? 1 : 0;	// CMR7: host is always player 0; per-client D_init seed
+	printf("Hosting Game. Local Refresh Rate: %dHz, WiFi: %d\n", gTargetFPS, sClientConnectionHint[0]);
 
 
 			/* GET SOME NAMES */
@@ -653,7 +763,7 @@ NetConfigMessage		message;
 			message.difficulty		= gDifficulty;			// set difficulty
 			message.tagDuration		= gTagDuration;					// set tag duration
 			message.targetFPS		= gTargetFPS;					// Set the global target FPS
-			message.useRedundancy	= gUseRedundancy;				// Set Redundancy Flag
+			message.reserved		= 0;							// CMR7: was useRedundancy (retired)
 
 			status = NSpMessage_Send(gNetGame, &message.h, kNSpSendFlag_Registered);	// send message
 			if (status)
@@ -701,9 +811,8 @@ void HandleGameConfigMessage(NetConfigMessage* inMessage)
 	gDifficulty			= inMessage->difficulty;
 	gTagDuration		= inMessage->tagDuration;
 	gTargetFPS			= inMessage->targetFPS;
-	gUseRedundancy		= inMessage->useRedundancy;
 
-	printf("Join Config Received. TargetFPS: %d, Redundancy: %d\n", gTargetFPS, gUseRedundancy);
+	printf("Join Config Received. TargetFPS: %d\n", gTargetFPS);
 
 
 	// Copy transient settings
@@ -871,7 +980,7 @@ short							i;
 	for (i = 0; i < MAX_PLAYERS; i++)								// control bits
 	{
 		gHostOutMess.controlBits[i] = gPlayerInfo[i].controlBits;
-		gHostOutMess.controlBitsNew[i] = gPlayerInfo[i].controlBits_New;
+		gHostOutMess.controlBitsNew[i] = gPlayerInfo[i].controlBits_New;	// host-derived edges (Host_ConsumeClientInputs / GetLocalKeyState / AI)
 		gHostOutMess.analogSteering[i] = gPlayerInfo[i].analogSteering;
 
 		if (gPlayerInfo[i].isComputer)
@@ -889,7 +998,15 @@ short							i;
 			gHostOutMess.syncPos[i] = gPlayerInfo[i].objNode->Coord;
 			gHostOutMess.syncRotY[i] = gPlayerInfo[i].objNode->Rot.y;
 		}
+
+		// CMR7 telemetry / ack: last REAL input seq applied, live queue depth + target depth, input flags.
+		gHostOutMess.ackInputSeq[i]	= sLastApplied[i].lastAppliedSeq;
+		gHostOutMess.queueDepth[i]	= (uint8_t) Queue_Count(i);
+		gHostOutMess.targetDepth[i]	= sDepth[i].targetDepth;
+		gHostOutMess.inputFlags[i]	= sInputFlags[i];
 	}
+
+	gHostOutMess.eventCount = 0;									// frame-aligned events populated in Stage 4
 
 			/* SEND IT */
 
@@ -1085,41 +1202,14 @@ Boolean Client_CheckIfMorePacketsWaiting(void)
 
 /************** CLIENT SEND CONTROL INFO TO HOST *********************/
 //
-// At the end of each frame, the client sends the new control state info to the host for
-// the next frame.
+// The client sends its current control state to the host. CMR7: a single packet per call,
+// stamped with a client-owned monotonic inputSeq. The host derives edges and substitutes
+// missing inputs, so the 8-frame redundancy history (dead weight on ordered TCP) is gone.
 //
-
-// Client redundancy history. File-scope (not function-static) so ResetNetGameTransientState
-// can clear it between games — otherwise stale history from a prior game leaks into the next.
-static uint32_t					historyControlBits[8];
-static OGLVector2D				historyAnalog[8];
 
 void ClientSend_ControlInfoToHost(void)
 {
-OSStatus						status;
-
 	GAME_ASSERT(gIsNetworkClient);
-
-				/* UPDATE HISTORY */
-	
-	if (gUseRedundancy)
-	{
-		// Shift history
-		for (int k = 7; k > 0; k--)
-		{
-			historyControlBits[k] = historyControlBits[k-1];
-			historyAnalog[k] = historyAnalog[k-1];
-		}
-		
-		// Store previous frame (current info before sending)
-		// Wait! This function sends info for NEXT frame?
-		// "ClientSend_ControlInfoToHost: send this info to the host to be used the next frame"
-		// The values in gPlayerInfo are what we just read.
-		// So we want to save THIS frame to history for NEXT packet.
-		historyControlBits[0] = gPlayerInfo[gMyNetworkPlayerNum].controlBits;
-		historyAnalog[0] = gPlayerInfo[gMyNetworkPlayerNum].analogSteering;
-	}
-
 
 				/* BUILD MESSAGE */
 
@@ -1129,240 +1219,334 @@ OSStatus						status;
 	gClientOutMess.h.what 			= kNetClientControlInfoMessage;			// set message type
 	gClientOutMess.h.messageLen 	= sizeof(gClientOutMess);				// set size of message
 
-	gClientOutMess.frameCounter		= gClientSendCounter[gMyNetworkPlayerNum]++;	// send client frame counter & inc
 	gClientOutMess.playerNum		= gMyNetworkPlayerNum;
-	gClientOutMess.controlBits 		= gPlayerInfo[gMyNetworkPlayerNum].controlBits;
-	gClientOutMess.controlBitsNew  	= gPlayerInfo[gMyNetworkPlayerNum].controlBits_New;
-	gClientOutMess.analogSteering	= gPlayerInfo[gMyNetworkPlayerNum].analogSteering;
 	gClientOutMess.pauseState		= gPlayerInfo[gMyNetworkPlayerNum].net.pauseState;
-
-	if (gUseRedundancy)
-	{
-		for (int k = 0; k < 8; k++)
-		{
-			gClientOutMess.prevControlBits[k] = historyControlBits[k];
-			gClientOutMess.prevAnalogSteering[k] = historyAnalog[k];
-		}
-	}
+	gClientOutMess.inputSeq			= gClientSendCounter[gMyNetworkPlayerNum]++;	// monotonic, client-owned
+	gClientOutMess.lastHostFrameSeen= gHostSendCounter;							// RTT/diagnostics
+	gClientOutMess.controlBits 		= gPlayerInfo[gMyNetworkPlayerNum].controlBits;
+	gClientOutMess.analogSteering	= gPlayerInfo[gMyNetworkPlayerNum].analogSteering;
 
 			/* SEND IT */
 
-	status = NSpMessage_Send(gNetGame, &gClientOutMess.h, kNSpSendFlag_Registered);
-//	if (status)
-//		DoFatalAlert("ClientSend_ControlInfoToHost: NSpMessage_Send failed!");
+	NSpMessage_Send(gNetGame, &gClientOutMess.h, kNSpSendFlag_Registered);	// Stage 1 SendOrEnqueue: non-blocking
 }
 
+/*************** HOST PUMP CLIENT INPUTS ***********************/
+//
+// CMR7: non-blocking drain of every readable message. Client control packets are arrival-
+// timestamped (feeding the per-client jitter estimator) and pushed into their per-player
+// queue; everything else goes to the standard dispatcher. The host NEVER blocks here.
+// Called from Net_Pump's host branch.
+//
 
-/*************** HOST GET CONTROL INFO FROM CLIENTS ***********************/
-
-#define NET_QUEUE_SIZE 64
-typedef struct {
-    int head;
-    int tail;
-    NetClientControlInfoMessageType msgs[NET_QUEUE_SIZE];
-} PacketQueue;
-
-static PacketQueue sHostInputQueues[MAX_PLAYERS];
-
-// Init queues (Call this somewhere? Or rely on 0-init? Static is 0-init. Correct.)
-
-static void Queue_Push(int playerNum, NetClientControlInfoMessageType* msg)
+void Host_PumpClientInputs(void)
 {
-    if (!IsValidPlayerNum(playerNum)) return;		// never index sHostInputQueues[] with a wire-supplied value out of range
-    PacketQueue* q = &sHostInputQueues[playerNum];
-    // Check overflow
-    int next = (q->tail + 1) % NET_QUEUE_SIZE;
-    if (next != q->head)
-    {
-        q->msgs[q->tail] = *msg;
-        q->tail = next;
-    }
-}
+	if (!gIsNetworkHost || !gNetGame)
+		return;
 
-static NetClientControlInfoMessageType* Queue_Peek(int playerNum)
-{
-    if (!IsValidPlayerNum(playerNum)) return NULL;
-    PacketQueue* q = &sHostInputQueues[playerNum];
-    if (q->head == q->tail) return NULL;
-    return &q->msgs[q->head];
-}
+	double perfFreq = (double) SDL_GetPerformanceFrequency();
 
-static void Queue_Pop(int playerNum)
-{
-    if (!IsValidPlayerNum(playerNum)) return;
-    PacketQueue* q = &sHostInputQueues[playerNum];
-    if (q->head != q->tail)
-    {
-        q->head = (q->head + 1) % NET_QUEUE_SIZE;
-    }
-}
-
-// Clear all per-process net state that must NOT survive from one net game to the next.
-// Called from both the setup paths and EndNetworkGame so stale state can never wedge a
-// later game (the host input queues, the redundancy history, and the stall-strike counter
-// all used to persist, which is why a second hosted game in the same process would hang
-// then fatally error out).
-static void ResetNetGameTransientState(void)
-{
-	memset(sHostInputQueues, 0, sizeof(sHostInputQueues));
-	memset(historyControlBits, 0, sizeof(historyControlBits));
-	memset(historyAnalog, 0, sizeof(historyAnalog));
-	gTimeoutCounter = 0;
-}
-
-// Helper to Apply msg to gPlayerInfo (Shared logic)
-static void ApplyClientMessage(NetClientControlInfoMessageType* mess)
-{
-    int i = mess->playerNum;
-    if (!IsValidPlayerNum(i)) return;
-    gPlayerInfo[i].controlBits	= mess->controlBits;
-    gPlayerInfo[i].controlBits_New = mess->controlBitsNew;
-    gPlayerInfo[i].analogSteering = mess->analogSteering;
-    gPlayerInfo[i].net.pauseState = mess->pauseState;
-}
-
-// Recover N from Future Packet (N+Gap)
-static Boolean RecoverFromFuture(NetClientControlInfoMessageType* future, int expectedFrame)
-{
-    int i = future->playerNum;
-    if (!IsValidPlayerNum(i)) return false;
-    if (!gUseRedundancy) return false;
-    
-    int gap = future->frameCounter - expectedFrame;
-    int historyIndex = gap - 1; // Gap=1(N+1) -> Idx 0. Gap=2(N+2) -> Idx 1.
-    
-    if (historyIndex >= 0 && historyIndex < 8)
-    {
-        printf("Recovering Frame %d from Future Packet %d\n", expectedFrame, future->frameCounter);
-        gPlayerInfo[i].controlBits = future->prevControlBits[historyIndex];
-        gPlayerInfo[i].controlBits_New = 0;
-        gPlayerInfo[i].analogSteering = future->prevAnalogSteering[historyIndex];
-        gPlayerInfo[i].net.pauseState = 0;
-        return true;
-    }
-    return false;
-}
-
-void HostReceive_ControlInfoFromClients(void)
-{
-NSpMessageHeader 					*inMess;
-uint32_t								tick;
-Boolean								abort = false;
-
-	GAME_ASSERT(gIsNetworkHost);
-
-	ClearPlayerSyncMask();
-	MarkPlayerSynced(NSpPlayer_GetMyID(gNetGame));			// the host already has its own info
-
-	tick = TickCount();										// start tick for timeout
-
-	while (!AreAllPlayersSynced() && !abort)				// loop until I've got the message from all players
+	NSpMessageHeader* inMess;
+	while ((inMess = NSpMessage_Get(gNetGame)) != NULL)
 	{
-		// 1. Process Queues (Buffers)
-		//
-		// The sync mask is keyed on NSp slot IDs (AreAllPlayersSynced compares against
-		// NSpGame_GetActivePlayersIDMask), but the queues/counters are indexed by internal
-		// playerNum. Mark/check the mask by gPlayerInfo[i].net.nspPlayerID, keep the queue and
-		// counter access playerNum-based, and skip bots (no live NSp ID, never in the target
-		// mask) so lobby churn (e.g. IDs {0,2} / playerNums {0,1}) can't wedge the barrier.
-		for (int i = 0; i < gNumRealPlayers; i++)
+		Boolean over = false;
+
+		if (inMess->what == kNetClientControlInfoMessage)
 		{
-			if (gPlayerInfo[i].isComputer) continue;	// bots have no NSp ID, not in target mask
+			NetClientControlInfoMessageType* cMsg = (NetClientControlInfoMessageType*) inMess;
 
-			NSpPlayerID id = gPlayerInfo[i].net.nspPlayerID;
-
-			if (PlayerIsSynced(id)) continue; // Already have data for this frame
-
-			NetClientControlInfoMessageType* msg = Queue_Peek(i);
-			while (msg)
+			// Drop malformed / out-of-range / self / bot-slot packets before any array index.
+			if (inMess->messageLen >= sizeof(NetClientControlInfoMessageType)
+				&& IsValidPlayerNum(cMsg->playerNum)
+				&& cMsg->playerNum != gMyNetworkPlayerNum
+				&& !gPlayerInfo[cMsg->playerNum].isComputer)
 			{
-				if (msg->frameCounter < gClientSendCounter[i])
+				int p = cMsg->playerNum;
+
+						/* FEED THE INTER-ARRIVAL JITTER RING (drives adaptive depth D_i) */
+
+				uint64_t now = SDL_GetPerformanceCounter();
+				if (sDepth[p].lastArrivalPC != 0 && perfFreq > 0.0)
 				{
-					// Discard Old Packet
-					Queue_Pop(i);
-					msg = Queue_Peek(i);
+					float dt = (float)((double)(now - sDepth[p].lastArrivalPC) / perfFreq);
+					sDepth[p].deltas[sDepth[p].head] = dt;
+					sDepth[p].head = (sDepth[p].head + 1) % JITTER_WINDOW;
+					if (sDepth[p].count < JITTER_WINDOW)
+						sDepth[p].count++;
 				}
-				else if (msg->frameCounter == gClientSendCounter[i])
-				{
-					// Exact Match
-					ApplyClientMessage(msg);
-					gClientSendCounter[i]++;
-					MarkPlayerSynced(id);
-					Queue_Pop(i);
-					break; // Done for this player
-				}
-				else // Future
-				{
-					// Try Recovery
-					if (RecoverFromFuture(msg, gClientSendCounter[i]))
-					{
-						gClientSendCounter[i]++;
-						MarkPlayerSynced(id);
-						// Do NOT Pop. Keep future packet for later.
-					}
-					break; // Wait for missing packets (or used recovery)
-				}
+				sDepth[p].lastArrivalPC = now;
+
+				Queue_Push(p, cMsg);
 			}
-		}
-
-		if (AreAllPlayersSynced()) break;
-
-		// 2. Poll Network
-		inMess = NSpMessage_Get(gNetGame);					// get message
-		if (inMess)
-		{
-			tick = TickCount();								// reset tick for timeout
-			switch(inMess->what)
-			{
-				case kNetClientControlInfoMessage:
-				{
-					NetClientControlInfoMessageType* cMsg = (NetClientControlInfoMessageType*)inMess;
-
-					// Drop a malformed or out-of-range client packet before it touches any array.
-					if (inMess->messageLen < sizeof(NetClientControlInfoMessageType)
-						|| !IsValidPlayerNum(cMsg->playerNum))
-					{
-						break;
-					}
-
-					// Push to the per-player queue; Step 1 (above) consumes it next loop iteration.
-					Queue_Push(cMsg->playerNum, cMsg);
-					break;
-				}
-
-				default:
-					if (HandleOtherNetMessage(inMess))
-					{
-						abort = true;
-					}
-					break;
-			}
-			NSpMessage_Release(gNetGame, inMess);			// dispose of message
 		}
 		else
 		{
-			SDL_PumpEvents();			// keep the OS/window responsive while we block for client input
-			SDL_Delay(1);				// yield a slice instead of pegging a core in a zero-sleep spin
-			Net_Pump();					// keep the broadcast ring draining toward a slow client while blocked
+			over = HandleOtherNetMessage(inMess);
 		}
 
-		if ((TickCount() - tick) > (DATA_TIMEOUT*60))		// see if we've been waiting longer than n seconds
+		NSpMessage_Release(gNetGame, inMess);
+
+		if (over || !gNetGameInProgress || gNetGame == nil)		// game torn down mid-drain (e.g. everybody left)
+			return;
+	}
+}
+
+
+/*************** HOST INPUT CONSUME HELPERS ***********************/
+
+static int CompareFloatAsc(const void* a, const void* b)
+{
+	float fa = *(const float*) a;
+	float fb = *(const float*) b;
+	return (fa < fb) ? -1 : ((fa > fb) ? 1 : 0);
+}
+
+// Commit a real applied packet as the new edge-derivation baseline + ack source.
+static void Host_CommitApplied(int i, const NetClientControlInfoMessageType* m)
+{
+	HostClientInputState* S = &sLastApplied[i];
+	S->controlBits		= m->controlBits;
+	S->analogSteering	= m->analogSteering;
+	S->pauseState		= m->pauseState;
+	S->lastAppliedSeq	= m->inputSeq;
+	S->valid			= true;
+	S->subStreak		= 0;
+	gClientSendCounter[i] = m->inputSeq + 1;			// bookkeeping mirror (stale-discard baseline)
+}
+
+// Recompute the P95-jitter-derived baseline depth (<=4Hz) and slowly decay the target depth.
+static void Host_UpdateDepth(int i)
+{
+	double F = (gTargetFPS > 0) ? (1.0 / gTargetFPS) : (1.0 / 60.0);
+	double now = (double) SDL_GetPerformanceCounter() / (double) SDL_GetPerformanceFrequency();
+
+	if (now - sDepth[i].baselineSec >= 0.25)			// throttle the recompute to <=4Hz
+	{
+		int n = sDepth[i].count;
+		if (n > 0)
 		{
-			gTimeoutCounter++;								// keep track of how often this happens
-			if (gTimeoutCounter > 3)
+			float tmp[JITTER_WINDOW];
+			for (int k = 0; k < n; k++)
 			{
-				NetGameFatalError(kNetSequence_ErrorNoResponseFromClients);
-				return;
+				float dev = sDepth[i].deltas[k] - (float) F;
+				tmp[k] = (dev < 0.0f) ? -dev : dev;
 			}
-			tick = TickCount();														// reset tick
+			qsort(tmp, n, sizeof(float), CompareFloatAsc);
+
+			int idx = (int) ceilf(0.95f * (float) n) - 1;
+			if (idx < 0) idx = 0;
+			if (idx >= n) idx = n - 1;
+
+			float p95 = tmp[idx];
+			int dbase = (int) ceilf(p95 / (float) F) + 1;
+			if (dbase < 1) dbase = 1;
+			if (dbase > 8) dbase = 8;
+
+			sDepth[i].baselineDepth = (uint8_t) dbase;
+			if (dbase > (int) sDepth[i].targetDepth)
+				sDepth[i].targetDepth = (uint8_t) dbase;
 		}
+		sDepth[i].baselineSec = now;
 	}
 
-	// We got a full frame of input from everyone (the loop only exits cleanly when all
-	// players are synced). Clear the stall-strike counter so the 4-strike fatal requires
-	// 4 *consecutive* stalled frames, not 4 cumulative stalls over the whole session.
-	if (!abort)
-		gTimeoutCounter = 0;
+	// Decay one frame per 2s while above the live baseline and above the floor.
+	sDepth[i].decayAccumSec += (float) F;
+	if (sDepth[i].decayAccumSec >= 2.0f
+		&& sDepth[i].targetDepth > sDepth[i].baselineDepth
+		&& sDepth[i].targetDepth > 1)
+	{
+		sDepth[i].targetDepth--;
+		sDepth[i].decayAccumSec = 0.0f;
+	}
+}
+
+
+/*************** HOST CONSUME CLIENT INPUTS ***********************/
+//
+// CMR7: top of the host frame, before HostSend. Resolves each remote client's input for THIS
+// frame from its queue: SUBSTITUTE on underrun (hold last real input, never advance the ack),
+// COALESCE a backlog down to D_i (OR-merging per-step edges), else APPLY exactly one packet.
+// The host's own slot and bot/dropped slots are skipped (driven by GetLocalKeyState / AI).
+//
+
+void Host_ConsumeClientInputs(void)
+{
+	if (!gIsNetworkHost)
+		return;
+
+	memset(sInputFlags, 0, sizeof(sInputFlags));
+
+	const uint32_t kMovementBits =
+		(1u << kControlBit_Forward) | (1u << kControlBit_Backward) | (1u << kControlBit_Brakes);
+
+			/* BOUNDED GRACE: re-poll a couple of times to catch near-miss kernel-buffered packets */
+
+	for (int g = 0; g < GRACE_RETRIES; g++)
+	{
+		Boolean anyEmpty = false;
+		for (int i = 0; i < MAX_PLAYERS; i++)
+		{
+			if (i == gMyNetworkPlayerNum || gPlayerInfo[i].isComputer)
+				continue;
+			if (Queue_Count(i) == 0)
+			{
+				anyEmpty = true;
+				break;
+			}
+		}
+		if (!anyEmpty)
+			break;
+		SDL_Delay(1);
+		Net_Pump();									// re-drain (host branch pumps client inputs into the queues)
+	}
+
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		if (i == gMyNetworkPlayerNum)				// host reads its own input at Step 3
+			continue;
+		if (gPlayerInfo[i].isComputer)				// bot/dropped -> AI drives the bits
+			continue;
+
+		HostClientInputState* S = &sLastApplied[i];
+		int D = sDepth[i].targetDepth;
+		if (D < 1) D = 1;
+
+				/* DISCARD STALE PACKETS (dups / already-consumed pre-roll) */
+
+		NetClientControlInfoMessageType* p;
+		while ((p = Queue_Peek(i)) != NULL && p->inputSeq <= S->lastAppliedSeq)
+			Queue_Pop(i);
+
+		int B = Queue_Count(i);
+
+		if (B == 0)
+		{
+					/* ---- SUBSTITUTE (underrun): hold last real input, never advance the ack ---- */
+
+			gPlayerInfo[i].controlBits		= S->valid ? S->controlBits : 0;
+			gPlayerInfo[i].controlBits_New	= 0;								// no new edges while silent
+			gPlayerInfo[i].analogSteering	= S->valid ? S->analogSteering : (OGLVector2D){0,0};
+			gPlayerInfo[i].net.pauseState	= S->valid ? S->pauseState : 0;		// HELD: a radio blip never spuriously unpauses
+
+			if (S->subStreak < 0xFFFF)
+				S->subStreak++;
+
+			if (S->subStreak > SUB_DECAY_AFTER)
+			{
+				// Graceful coast: decay the APPLIED bits/analog ONLY. Leave S->controlBits (the
+				// edge baseline) intact so a still-held button does not re-fire as a NEW edge on
+				// recovery (which would double-fire e.g. a weapon throw).
+				gPlayerInfo[i].analogSteering.x *= 0.9f;
+				gPlayerInfo[i].analogSteering.y *= 0.9f;
+				gPlayerInfo[i].controlBits &= ~kMovementBits;
+			}
+
+			sInputFlags[i] |= INPUT_FLAG_SUBSTITUTED;
+			if (sDepth[i].targetDepth < 8)
+				sDepth[i].targetDepth++;										// immediate underrun bump
+			continue;
+		}
+
+		if (B > D + 1)
+		{
+					/* ---- COALESCE down to D: OR-merge per-step edges, apply the newest ---- */
+
+			int toPop = B - D;
+			uint32_t prev = S->controlBits;
+			uint32_t merged = 0;
+			NetClientControlInfoMessageType last;
+			memset(&last, 0, sizeof(last));
+
+			for (int k = 0; k < toPop; k++)
+			{
+				p = Queue_Peek(i);
+				if (!p) break;
+				merged |= Host_DeriveEdges(prev, p->controlBits);	// preserve EVERY press across the window
+				prev = p->controlBits;
+				last = *p;
+				Queue_Pop(i);
+			}
+
+			gPlayerInfo[i].controlBits		= last.controlBits;
+			gPlayerInfo[i].controlBits_New	= merged;
+			gPlayerInfo[i].analogSteering	= last.analogSteering;
+			gPlayerInfo[i].net.pauseState	= last.pauseState;
+
+			Host_CommitApplied(i, &last);
+			sInputFlags[i] |= INPUT_FLAG_COALESCED;
+		}
+		else
+		{
+					/* ---- APPLY exactly one real packet ---- */
+
+			p = Queue_Peek(i);
+			gPlayerInfo[i].controlBits		= p->controlBits;
+			gPlayerInfo[i].controlBits_New	= Host_DeriveEdges(S->controlBits, p->controlBits);
+			gPlayerInfo[i].analogSteering	= p->analogSteering;
+			gPlayerInfo[i].net.pauseState	= p->pauseState;
+
+			Host_CommitApplied(i, p);
+			Queue_Pop(i);
+		}
+
+		Host_UpdateDepth(i);
+	}
+}
+
+
+/*************** HOST INIT INPUT CONTROL ***********************/
+//
+// Called once by the host right before the game loop. ResetNetGameTransientState() has
+// already zeroed the per-client state; here we seed each remote client's adaptive depth
+// from its WiFi/wired hint (wired -> D=2, WiFi -> D=6). The host slot and bots are left at
+// the default (0, treated as 1 by the consumer).
+//
+
+void Host_InitInputControl(void)
+{
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		if (i == gMyNetworkPlayerNum || gPlayerInfo[i].isComputer)
+			continue;
+		sDepth[i].targetDepth = (sClientConnectionHint[i] == 1) ? 6 : 2;
+	}
+}
+
+
+/*************** SAMPLE AND SEND LOCAL INPUT (CLIENT, WALL-CLOCK) ***********************/
+//
+// CMR7 (G1): the client's uplink is paced by the wall clock, decoupled from host-packet
+// receipt, so a downlink stall never silences the uplink. Emits one input packet per F
+// seconds, bursting up to MAX_SAMPLE_BURST to refill the host's backlog after a stall, and
+// resyncing after a long wall-clock gap (app suspend) to avoid a flood of stale packets.
+//
+
+void SampleAndSendLocalInput(Boolean* outSchedulePause)
+{
+	GAME_ASSERT(gIsNetworkClient);
+
+	double F = (gTargetFPS > 0) ? (1.0 / gTargetFPS) : (1.0 / 60.0);
+	double now = (double) SDL_GetPerformanceCounter() / (double) SDL_GetPerformanceFrequency();
+
+	if (sNextSampleTime == 0.0 || (now - sNextSampleTime) > 0.250)	// first call / suspend resync
+		sNextSampleTime = now;
+
+	int burst = 0;
+	while (now >= sNextSampleTime && burst < MAX_SAMPLE_BURST)
+	{
+		ReadKeyboard();
+		GetLocalKeyState();
+		// GetNewNeedStateAnyP is edge-triggered: OR into the caller's flag so a burst can't drop the edge.
+		if (GetNewNeedStateAnyP(kNeed_UIPause))
+			*outSchedulePause = true;
+		gPlayerInfo[gMyNetworkPlayerNum].net.pauseState = *outSchedulePause;
+
+		ClientSend_ControlInfoToHost();				// inputSeq = gClientSendCounter[me]++
+
+		sNextSampleTime += F;
+		burst++;
+		now = (double) SDL_GetPerformanceCounter() / (double) SDL_GetPerformanceFrequency();
+	}
 }
 
 

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -91,6 +91,8 @@ void Net_Pump(void)
 
 	if (gIsNetworkHost)
 		Host_PumpClientInputs();			// CMR7: non-blocking drain of client inputs into per-player queues
+	else if (gIsNetworkClient)
+		Client_PumpHostPackets();			// CMR7 Stage 3: non-blocking drain of host control packets into the ring
 }
 
 
@@ -262,6 +264,7 @@ void ResetNetGameTransientState(void)
 	gHostSendCounter = 0;
 	memset(gClientSendCounter, 0, sizeof(gClientSendCounter));
 	sNextSampleTime = 0.0;
+	ResetClientHostRing();					// CMR7 Stage 3: empty the client host-packet ring + reset hold timers
 }
 
 
@@ -1082,122 +1085,237 @@ static Boolean Client_InGame_HandleHostControlInfoMessage(NetHostControlInfoMess
 	return true;
 }
 
+
+#pragma mark - Client host-packet ring (CMR7 Stage 3)
+
+//
+// CMR7 Stage 3: the client no longer blocks waiting for the host's per-frame control
+// packet. Net_Pump drains every readable host packet (non-blocking) into this ordered
+// 32-slot ring (~530ms @60fps); the PlayArea loop then consumes up to K_max per render
+// frame, applying each via the VERBATIM Client_InGame_HandleHostControlInfoMessage and
+// stepping the sim once per applied packet. An empty ring => hold-last-frame.
+//
+// The ring is NEVER drained past full: unread bytes stay in the kernel socket buffer
+// (TCP backpressure) so a host control packet is never dropped — dropping a middle packet
+// would make the next one trip the handler's lost-packet fatal (frameCounter > counter).
+//
+
+#define CLIENT_HOST_RING_SIZE	32
+#define CLIENT_HOLD_BADGE_TICKS	15				// 250ms @60Hz of continuous host absence => show badge
+
+// A ring slot carries EITHER a host control packet OR a verbatim copy of a non-control host
+// message (e.g. kNSpPlayerLeft), so BOTH are applied in exact host-stream (TCP) order during
+// catch-up. Applying a sim-affecting non-control message inline while control frames sit
+// un-applied in the ring would draw the synced gSimRNG (ChooseTaggedPlayer) / mutate the
+// simulated-car set at the wrong stream position => randomSeed desync FATAL.
+typedef enum
+{
+	kRingEntry_Control = 0,				// host per-frame control packet (advances the sim)
+	kRingEntry_Other,					// any other host message, dispatched via HandleOtherNetMessage
+} HostRingEntryKind;
+
+typedef struct
+{
+	HostRingEntryKind	kind;
+	union
+	{
+		NetHostControlInfoMessageType	control;						// kRingEntry_Control
+		uint8_t							other[kNSpMaxMessageLength];	// kRingEntry_Other: verbatim message bytes
+	} u;																// union align (>=4) keeps `other` valid for NSpMessageHeader*
+} HostRingEntry;
+
+typedef struct
+{
+	int								head;			// next slot to consume
+	int								tail;			// next slot to fill
+	HostRingEntry					slots[CLIENT_HOST_RING_SIZE];
+} HostPacketRing;									// empty: head==tail; full: (tail+1)%N==head
+
+static HostPacketRing	sClientHostRing;			// static => zero-init; reset in ResetClientHostRing
+static uint32_t			sLastHostArrivalTick = 0;	// tick of the most recent host packet PUSHED to the ring
+
+static inline Boolean HostRing_Full(void)
+{
+	return ((sClientHostRing.tail + 1) % CLIENT_HOST_RING_SIZE) == sClientHostRing.head;
+}
+
+static Boolean HostRing_PushControl(const NetHostControlInfoMessageType* msg)
+{
+	if (HostRing_Full())
+		return false;
+	HostRingEntry* e = &sClientHostRing.slots[sClientHostRing.tail];
+	e->kind = kRingEntry_Control;
+	e->u.control = *msg;
+	sClientHostRing.tail = (sClientHostRing.tail + 1) % CLIENT_HOST_RING_SIZE;
+	return true;
+}
+
+static Boolean HostRing_PushOther(const NSpMessageHeader* msg)
+{
+	if (HostRing_Full())
+		return false;
+	uint32_t len = msg->messageLen;
+	if (len < sizeof(NSpMessageHeader))		len = sizeof(NSpMessageHeader);		// never under-copy the header
+	if (len > kNSpMaxMessageLength)			len = kNSpMaxMessageLength;			// clamp a garbage length
+	HostRingEntry* e = &sClientHostRing.slots[sClientHostRing.tail];
+	e->kind = kRingEntry_Other;
+	memcpy(e->u.other, msg, len);
+	sClientHostRing.tail = (sClientHostRing.tail + 1) % CLIENT_HOST_RING_SIZE;
+	return true;
+}
+
+static Boolean HostRing_Pop(HostRingEntry* out)
+{
+	if (sClientHostRing.head == sClientHostRing.tail)
+		return false;
+	*out = sClientHostRing.slots[sClientHostRing.head];
+	sClientHostRing.head = (sClientHostRing.head + 1) % CLIENT_HOST_RING_SIZE;
+	return true;
+}
+
+// Clear the ring + hold timers so a second net game in the same process starts empty.
+void ResetClientHostRing(void)
+{
+	sClientHostRing.head = 0;
+	sClientHostRing.tail = 0;
+	sLastHostArrivalTick = TickCount();
+}
+
+//
+// Drain every readable host message into the ring (non-blocking). We only pull from the
+// socket while the ring has space, so a host control packet is never dropped (TCP
+// backpressure handles a sustained-full ring). Called from Net_Pump's client branch — the
+// only in-game client socket drain.
+//
+// CRITICAL ORDERING: every NON-control host message is ALSO staged into the same ordered ring
+// (not dispatched inline) so it is applied in exact host-stream order relative to the control
+// frames during catch-up. A relayed kNSpPlayerLeft runs PlayerUnexpectedlyLeavesGame ->
+// ChooseTaggedPlayer, a synced gSimRNG draw that also flips isComputer/isEliminated and the
+// simulated-car set. Handling it inline (while control frames N-1/N still sit un-applied in the
+// ring) would perturb gSimRNG at an EARLIER stream position than the host did, tripping the
+// next per-frame randomSeed check (kNetSequence_SeedDesync FATAL). Only kNSpGameTerminated,
+// which merely tears the session down and never touches gSimRNG / the sim set, stays inline.
+//
+void Client_PumpHostPackets(void)
+{
+	if (!gIsNetworkClient || !gNetGame)
+		return;
+
+	while (!HostRing_Full())									// only Get() while we can store it
+	{
+		NSpMessageHeader* inMess = NSpMessage_Get(gNetGame);	// non-blocking recv
+
+		if (inMess == NULL)
+			break;												// socket drained
+
+		if (inMess->what == kNetHostControlInfoMessage)
+		{
+			HostRing_PushControl((NetHostControlInfoMessageType*) inMess);	// guaranteed space (ring not full)
+			sLastHostArrivalTick = TickCount();								// arrival time for the hold badge
+		}
+		else if (inMess->what == kNSpGameTerminated)
+		{
+			HandleOtherNetMessage(inMess);						// teardown only (no gSimRNG / sim-set touch): act now
+		}
+		else
+		{
+			HostRing_PushOther(inMess);							// PlayerLeft / sync / etc.: apply in stream order
+		}
+
+		NSpMessage_Release(gNetGame, inMess);
+	}
+}
+
+//
+// Pop ONE staged host packet and apply it via the verbatim handler. Returns Applied
+// (counter advanced -> caller steps the sim), Dup (old/duplicate, dropped by the handler
+// -> no sim step), or Empty (ring drained). Does NOT step the simulation itself.
+//
+HostConsumeResult Client_ConsumeHostPacketFromRing(void)
+{
+	HostRingEntry entry;
+
+	if (!HostRing_Pop(&entry))
+		return kHostConsume_Empty;
+
+	if (entry.kind == kRingEntry_Other)
+	{
+		// A non-control host message (e.g. kNSpPlayerLeft) staged in exact stream order. Dispatch it
+		// at this FIFO position so any gSimRNG draw / sim-state change (ChooseTaggedPlayer, isComputer)
+		// lands where the host applied it. It neither advances the host counter nor steps the sim, so
+		// report Dup: the catch-up loop keeps draining the ring without burning a K_max slot or stepping.
+		HandleOtherNetMessage((NSpMessageHeader*) entry.u.other);
+		return kHostConsume_Dup;
+	}
+
+	Boolean applied = Client_InGame_HandleHostControlInfoMessage(&entry.u.control);	// VERBATIM apply (may also fatal inside)
+	return applied ? kHostConsume_Applied : kHostConsume_Dup;
+}
+
+//
+// True once no host packet has arrived for ~250ms of continuous absence. Keyed on ARRIVAL
+// time (not stepped==0) so a frame that only popped duplicates still counts as having
+// "heard" the host. Suppressed during the start-light countdown.
+//
+Boolean Client_IsHoldBadgeVisible(void)
+{
+	if (!gIsNetworkClient)
+		return false;
+	if (gNoCarControls)									// suppress during start-light countdown
+		return false;
+	return (TickCount() - sLastHostArrivalTick) > CLIENT_HOLD_BADGE_TICKS;
+}
+
+
+//
+// CMR7 Stage 3: RETAINED bounded shim — used ONLY by Paused.c and the loading barriers
+// (the in-game loop is now free-running via Net_Pump + the ring catch-up loop). It pumps
+// the network, applies EXACTLY ONE host packet, then returns; it NEVER steps the sim (the
+// pause callback drives its own MoveObjects, so stepping here would double-step). The old
+// zero-sleep spin is gone: an empty ring yields a slice instead of pegging a core.
+//
 void ClientReceive_ControlInfoFromHost(void)
 {
-NSpMessageHeader 					*inMess = NULL;
 uint32_t							tick;
-Boolean								gotIt = false;
 
 	GAME_ASSERT(gIsNetworkClient);
 
 	tick = TickCount();														// init tick for timeout
 
-	while (!gotIt)
+	while (true)
 	{
-		inMess = NSpMessage_Get(gNetGame);									// get message
+		Net_Pump();															// drain host packets into the ring + flush send rings
 
-		if (inMess)
+		HostConsumeResult r = Client_ConsumeHostPacketFromRing();
+		if (r == kHostConsume_Applied)
+			return;															// applied exactly one host frame
+		if (r == kHostConsume_Dup)
+			continue;														// duplicate: try the next one immediately
+
+			/* RING EMPTY — YIELD INSTEAD OF A ZERO-SLEEP SPIN */
+
+		SDL_PumpEvents();			// keep the OS/window responsive while we block for the host packet
+		SDL_Delay(1);				// yield a slice instead of pegging a core in a zero-sleep spin
+
+			/* SEE IF WE ARE NOT GETTING THE PACKET */
+
+		if ((TickCount() - tick) > (DATA_TIMEOUT*60))	// see if we've been waiting longer than n seconds
 		{
-				/* WE GOT A PACKET */
-
-			switch (inMess->what)
+			gTimeoutCounter++;								// keep track of how often this happens
+			if (gTimeoutCounter > 3)
 			{
-				case kNetHostControlInfoMessage:
-					gotIt = true;
-					Client_InGame_HandleHostControlInfoMessage((NetHostControlInfoMessageType*) inMess);
-					break;
-
-				default:
-					if (HandleOtherNetMessage(inMess))
-					{
-						gotIt = true;
-					}
-					break;
+				NetGameFatalError(kNetSequence_ErrorNoResponseFromHost);
+				return;
 			}
 
-			NSpMessage_Release(gNetGame, inMess);
-			inMess = NULL;
-		}
-		else
-		{
-			SDL_PumpEvents();			// keep the OS/window responsive while we block for the host packet
-			SDL_Delay(1);				// yield a slice instead of pegging a core in a zero-sleep spin
-			Net_Pump();					// keep the uplink ring draining while blocked (avoids host<->client mutual wait)
-
-				/* SEE IF WE ARE NOT GETTING THE PACKET */
-				//
-				// If this happens, then it is possible that Net Sprocket lost a packet.  There is no way to know who's packet got lost
-				// so go ahead and send our most recent packet again in case it was us.  The Host will throw out any dupes that it gets.
-				//
-				// [SOURCE PORT NOTE: I don't think we should resend packets since we're using TCP for everything]
-
-			if ((TickCount() - tick) > (DATA_TIMEOUT*60))	// see if we've been waiting longer than n seconds
-			{
-				gTimeoutCounter++;								// keep track of how often this happens
-				if (gTimeoutCounter > 3)
-				{
-					NetGameFatalError(kNetSequence_ErrorNoResponseFromHost);
-					return;
-				}
-
-#if 0	// SOURCE PORT: DON'T RESEND - We're using TCP!
-				NSpMessage_Send(gNetGame, &gClientOutMess.h, kNSpSendFlag_Registered);	// resend the last message
-#endif
-
-				tick = TickCount();														// reset tick
-			}
+			tick = TickCount();														// reset tick
 		}
 	}
 }
 
 
-/**************** CLIENT CHECK IF MORE PACKETS WAITING *****************/
-//
-// Returns true if there is another Host Control Info packet waiting in the buffer.
-//
-Boolean Client_CheckIfMorePacketsWaiting(void)
-{
-	if (!gNetGame)
-		return false;
-		
-	// Peek at the socket to see if there is data
-	// Note: NSpMessage_Get does a recv(), so we just try to get a message.
-	// Since we are non-blocking, this is effectively a peek if we don't break the message handling.
-	// However, NSpMessage_Get consumes the message.
-	// So we need to handle it OR peek.
-	
-	// Actually, looking at NSpMessage_GetAsClient loop in Main.c:
-	// The game loop calls ClientReceive_ControlInfoFromHost blocking.
-	// We want to know if we should loop *again*.
-	// BUT ClientReceive_ControlInfoFromHost *consumes* the message.
-	
-	// The plan says: "Refactor the game loop... if (morePackets) ClientReceive_PollControlInfo()"
-	// But ClientReceive_ControlInfoFromHost handles the message internally.
-	
-	// Let's implement this by peeking NSpMessage_Get and if it returns a specific message type, we handle it and return true.
-	
-	NSpMessageHeader* message = NSpMessage_Get(gNetGame);
-	if (message)
-	{
-		if (message->what == kNetHostControlInfoMessage)
-		{
-			// We got another frame! Handle it immediately.
-			Client_InGame_HandleHostControlInfoMessage((NetHostControlInfoMessageType*) message);
-			NSpMessage_Release(gNetGame, message);
-			return true;
-		}
-		else
-		{
-			// Some other message, handle it standard way
-			HandleOtherNetMessage(message);
-			NSpMessage_Release(gNetGame, message);
-			return false; // Not a control info packet, so don't skip frame for this
-		}
-	}
-	
-	return false;
-}
-
+// (CMR7 Stage 3: Client_CheckIfMorePacketsWaiting DELETED — dead since the free-running
+// receive rewrite; host packets are now drained into the ring by Client_PumpHostPackets.)
 
 
 /************** CLIENT SEND CONTROL INFO TO HOST *********************/

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -73,6 +73,25 @@ NetHostControlInfoMessageType	gHostOutMess;
 NetClientControlInfoMessageType	gClientOutMess;
 
 
+#pragma mark - Net pump
+
+/********** NET PUMP **********/
+//
+// Stage 1: drain the per-socket non-blocking send rings. Called at frame start (Main.c
+// PlayArea loop) and once per iteration inside the still-blocking Stage-1 receive loops so
+// a backlogged uplink/broadcast keeps moving while the main thread waits — this is what
+// prevents a host<->client mutual-wait deadlock. No-op outside a net game.
+//
+
+void Net_Pump(void)
+{
+	if (!gNetGameInProgress || gNetGame == nil)
+		return;
+
+	NSpGame_FlushSends(gNetGame);
+}
+
+
 #pragma mark - Net fatal error
 
 
@@ -986,6 +1005,7 @@ Boolean								gotIt = false;
 		{
 			SDL_PumpEvents();			// keep the OS/window responsive while we block for the host packet
 			SDL_Delay(1);				// yield a slice instead of pegging a core in a zero-sleep spin
+			Net_Pump();					// keep the uplink ring draining while blocked (avoids host<->client mutual wait)
 
 				/* SEE IF WE ARE NOT GETTING THE PACKET */
 				//
@@ -1323,6 +1343,7 @@ Boolean								abort = false;
 		{
 			SDL_PumpEvents();			// keep the OS/window responsive while we block for client input
 			SDL_Delay(1);				// yield a slice instead of pegging a core in a zero-sleep spin
+			Net_Pump();					// keep the broadcast ring draining toward a slow client while blocked
 		}
 
 		if ((TickCount() - tick) > (DATA_TIMEOUT*60))		// see if we've been waiting longer than n seconds

--- a/Source/Network/NetLow.c
+++ b/Source/Network/NetLow.c
@@ -54,6 +54,27 @@ int gNetPort = 49959;
 #define SOCKET_SNDBUF_SIZE 65536
 #define SOCKET_RCVBUF_SIZE 65536
 
+// Per-socket non-blocking send ring (Stage 1). Absorbs whatever the kernel send buffer
+// can't take in one shot so the main thread never blocks retrying a slow/stalled peer.
+// 32 KB ~= 2s of host control msgs (~290B @60pps) or ~10s of client msgs (~52B); a single
+// max message (kNSpMaxMessageLength) always fits an empty ring, so overflow only ever comes
+// from sustained backlog -> the existing kick (host) / terminate (client) path.
+#define SEND_RING_CAPACITY 32768
+
+typedef struct SendRing
+{
+	uint32_t					head;			// read cursor: next byte to send()
+	uint32_t					tail;			// write cursor: next byte to append
+	uint32_t					used;			// bytes currently queued (0..SEND_RING_CAPACITY)
+	uint32_t					highWater;		// telemetry: max 'used' ever seen
+	uint8_t						data[SEND_RING_CAPACITY];
+} SendRing;
+
+static void		SendRing_Reset(SendRing* r);
+static uint32_t	SendRing_FreeSpace(const SendRing* r);
+static bool		SendRing_Append(SendRing* r, const uint8_t* src, uint32_t len);
+static int		SendRing_Drain(SendRing* r, sockfd_t sockfd);
+
 typedef enum
 {
 	kNSpPlayerState_Offline,
@@ -68,6 +89,8 @@ typedef struct NSpPlayer
 	NSpPlayerState				state;
 	sockfd_t					sockfd;
 	char						name[kNSpPlayerNameLength];
+	SendRing					sendRing;		// host-side outbound queue for this peer socket (auto-reset by NSpPlayer_Clear's memset)
+	bool						needsLeaveNotify;	// host: a send to this peer failed; NSpMessage_GetAsHost owes the host's own NetHigh a synthetic kNSpPlayerLeft before the slot is reused
 } NSpPlayer;
 
 typedef struct NSpGame
@@ -85,8 +108,10 @@ typedef struct NSpGame
 	float						timeToReadvertise;
 
 	uint32_t					cookie;
-	
+
 	int							nextPollIndex;
+
+	SendRing					clientSendRing;	// client-side outbound queue for clientToHostSocket (zero-init by AllocPtrClear in NSpGame_Alloc)
 } NSpGame;
 
 typedef struct
@@ -110,7 +135,9 @@ static sockfd_t CreateTCPSocket(bool bindIt);
 static NSpGame* NSpGame_Unbox(NSpGameReference gameRef);
 static NSpGameReference NSpGame_Alloc(void);
 static void NSpPlayer_Clear(NSpPlayer* player);
-static int SendOnSocket(sockfd_t sockfd, NSpMessageHeader* header);
+static void NSpPlayer_DeferLeaveNotify(NSpPlayer* peer);
+static int SendBytesBlocking(sockfd_t sockfd, NSpMessageHeader* header);
+static int SendOrEnqueue(sockfd_t sockfd, SendRing* ring, NSpMessageHeader* header);
 
 static NSpPlayerID NSpGame_ClientSlotToID(NSpGameReference gameRef, int slot);
 static int NSpGame_ClientIDToSlot(NSpGameReference gameRef, NSpPlayerID id);
@@ -421,7 +448,7 @@ static NSpGameReference JoinLobby(const LobbyInfo* lobby)
 	NSpJoinRequestMessage* joinRequestMessage = AllocMessage(NSpJoinRequest, kNSpUnspecifiedEndpoint, kNSpHostID);
 	snprintf(joinRequestMessage->name, sizeof(joinRequestMessage->name), "CLIENT");
 
-	int rc = SendOnSocket(sockfd, &joinRequestMessage->header);
+	int rc = SendBytesBlocking(sockfd, &joinRequestMessage->header);	// one-shot lobby send: no per-socket ring exists yet
 	NSpMessage_Release(NULL, &joinRequestMessage->header);
 
 	if (rc != kNSpRC_OK)
@@ -488,6 +515,8 @@ NSpPlayerID NSpGame_AcceptNewClient(NSpGameReference gameRef)
 		newPlayer->state		= kNSpPlayerState_AwaitingHandshake;
 		newPlayer->sockfd		= newSocket;
 		snprintf(newPlayer->name, sizeof(newPlayer->name), "PLAYER %d", newPlayer->id);
+
+		SendRing_Reset(&newPlayer->sendRing);	// start a reused slot with an empty ring (defensive; NSpPlayer_Clear already zeroed it on the prior kick)
 	}
 	else
 	{
@@ -497,7 +526,7 @@ NSpPlayerID NSpGame_AcceptNewClient(NSpGameReference gameRef)
 		NSpJoinDeniedMessage* deniedMessage = AllocMessage(NSpJoinDenied, kNSpHostID, kNSpUnspecifiedEndpoint);
 		snprintf(deniedMessage->reason, sizeof(deniedMessage->reason), "THE GAME IS FULL.");
 
-		SendOnSocket(newSocket, &deniedMessage->header);
+		SendBytesBlocking(newSocket, &deniedMessage->header);	// one-shot denial; socket is closed immediately after
 		NSpMessage_Release(gameRef, &deniedMessage->header);
 
 		goto fail;
@@ -818,6 +847,31 @@ static NSpMessageHeader* NSpMessage_GetAsHost(NSpGame* game)
 		int i = (game->nextPollIndex + count) % MAX_CLIENTS;
 		count++;
 		NSpPlayer* player = &game->players[i];
+
+		// A host-side SEND failure (ring overflow / dead socket) flagged this slot but could not
+		// notify the host's own NetHigh from the send path. Synthesize the local kNSpPlayerLeft
+		// HERE — the same logical point the recv-side broken-pipe branch below does — so the host
+		// runs PlayerUnexpectedlyLeavesGame in lockstep with the remote clients (keeps isComputer /
+		// gNumGatheredPlayers / the synced-RNG draw count consistent, avoiding a seed desync). This
+		// must come before the IsSocketValid skip because the send path already closed the socket.
+		if (player->needsLeaveNotify)
+		{
+			player->needsLeaveNotify = false;
+
+			NSpPlayerLeftMessage* leftMessage = AllocMessage(NSpPlayerLeft, kNSpHostID, kNSpHostID);
+			leftMessage->playerCount		= NSpGame_GetNumActivePlayers(game) - 1;
+			leftMessage->playerID			= player->id;
+			CopyPlayerName(leftMessage->playerName, player->name);
+			message = &leftMessage->header;
+
+			// Round-Robin: start next search after this player
+			game->nextPollIndex = (i + 1) % MAX_CLIENTS;
+
+			// Tell the OTHER clients this guy left + clear the slot (socket already closed)
+			NSpPlayer_Kick(game, player->id);
+
+			continue;	// message != NULL -> loop exits with the synthesized leave
+		}
 
 		if (!IsSocketValid(player->sockfd))
 		{
@@ -1728,9 +1782,99 @@ int NSpGame_AdvertiseTick(NSpGameReference gameRef, float dt)
 	return kNSpRC_OK;
 }
 
+#pragma mark - Send rings
+
+static void SendRing_Reset(SendRing* r)
+{
+	r->head = 0;
+	r->tail = 0;
+	r->used = 0;
+	// highWater is per-session telemetry; it is cleared by the struct memset on alloc/clear.
+}
+
+static uint32_t SendRing_FreeSpace(const SendRing* r)
+{
+	return SEND_RING_CAPACITY - r->used;
+}
+
+// Append 'len' bytes to the ring. Returns false on overflow (caller treats as a send failure).
+static bool SendRing_Append(SendRing* r, const uint8_t* src, uint32_t len)
+{
+	if (len > SendRing_FreeSpace(r))
+	{
+		return false;
+	}
+
+	uint32_t first = SEND_RING_CAPACITY - r->tail;		// contiguous run to the buffer end
+	if (first > len)
+	{
+		first = len;
+	}
+
+	memcpy(r->data + r->tail, src, first);
+	if (len > first)
+	{
+		memcpy(r->data, src + first, len - first);		// wrap-around to the start
+	}
+
+	r->tail = (r->tail + len) % SEND_RING_CAPACITY;
+	r->used += len;
+	if (r->used > r->highWater)
+	{
+		r->highWater = r->used;
+	}
+
+	return true;
+}
+
+// Non-blocking drain of contiguous runs until the ring is empty or the socket would block.
+// Returns kNSpRC_OK (drained or buffer full) or kNSpRC_SendFailed (peer closed / hard error).
+static int SendRing_Drain(SendRing* r, sockfd_t sockfd)
+{
+	if (!IsSocketValid(sockfd))
+	{
+		return kNSpRC_SendFailed;
+	}
+
+	while (r->used > 0)
+	{
+		uint32_t run = SEND_RING_CAPACITY - r->head;	// contiguous bytes from head
+		if (run > r->used)
+		{
+			run = r->used;
+		}
+
+		ssize_t sent = send(sockfd, (const char*)(r->data + r->head), run, MSG_NOSIGNAL);
+
+		if (sent > 0)
+		{
+			r->head = (r->head + (uint32_t)sent) % SEND_RING_CAPACITY;
+			r->used -= (uint32_t)sent;
+			continue;
+		}
+
+		if (sent == 0)
+		{
+			return kNSpRC_SendFailed;					// peer closed
+		}
+
+		if (GetSocketError() == kSocketError_WouldBlock)
+		{
+			return kNSpRC_OK;							// buffer full; retry next pump
+		}
+
+		return kNSpRC_SendFailed;						// EPIPE/ECONNRESET/etc. -> dead
+	}
+
+	return kNSpRC_OK;
+}
+
 #pragma mark - NSpMessage
 
-static int SendOnSocket(sockfd_t sockfd, NSpMessageHeader* header)
+// Blocking send retained ONLY for the one-shot, non-gameplay lobby/teardown sends (join
+// request, game-full denial) where no per-socket ring exists yet. NEVER use on the
+// per-frame gameplay path — that is what SendOrEnqueue + the send rings are for.
+static int SendBytesBlocking(sockfd_t sockfd, NSpMessageHeader* header)
 {
 	GAME_ASSERT_MESSAGE(header->what != kNSpUndefinedMessage, "Did you forget to set header->what?");
 	GAME_ASSERT_MESSAGE(header->messageLen != 0xBADBABEE, "Did you forget to set header->messageLen?");
@@ -1803,6 +1947,111 @@ static int SendOnSocket(sockfd_t sockfd, NSpMessageHeader* header)
 	return kNSpRC_OK;
 }
 
+// Non-blocking enqueue: one send() attempt when the ring is empty, append the remainder
+// (or the whole message) to the ring otherwise. Returns kNSpRC_SendFailed on overflow
+// (~2s backlog) or a hard socket error -> the caller routes it to the existing kick (host)
+// / terminate (client) path. The main thread never blocks here.
+static int SendOrEnqueue(sockfd_t sockfd, SendRing* ring, NSpMessageHeader* header)
+{
+	GAME_ASSERT_MESSAGE(header->what != kNSpUndefinedMessage, "Did you forget to set header->what?");
+	GAME_ASSERT_MESSAGE(header->messageLen != 0xBADBABEE, "Did you forget to set header->messageLen?");
+	GAME_ASSERT(header->messageLen >= sizeof(NSpMessageHeader));
+	GAME_ASSERT(header->messageLen <= kNSpMaxMessageLength);
+	GAME_ASSERT(header->version == kNSpCMRProtocol4CC);
+
+	if (!IsSocketValid(sockfd))
+	{
+		printf("%s: invalid socket %d\n", __func__, (int) sockfd);
+		return kNSpRC_InvalidSocket;
+	}
+
+	uint32_t msgLen = header->messageLen;
+
+	// TCP is a byte stream: if anything is already queued we MUST append (sending fresh
+	// bytes now would interleave them ahead of the backlog and corrupt the stream).
+	if (ring->used == 0)
+	{
+		ssize_t sent = send(sockfd, (const char*)header, msgLen, MSG_NOSIGNAL);
+
+		if (sent == (ssize_t)msgLen)
+		{
+			return kNSpRC_OK;								// healthy path: whole message out immediately
+		}
+
+		if (sent > 0)
+		{
+			// Partial send on an empty ring: queue exactly the unsent remainder.
+			return SendRing_Append(ring, (const uint8_t*)header + sent, msgLen - (uint32_t)sent)
+				? kNSpRC_OK : kNSpRC_SendFailed;
+		}
+
+		if (sent == 0)
+		{
+			return kNSpRC_SendFailed;						// peer closed
+		}
+
+		if (GetSocketError() != kSocketError_WouldBlock)
+		{
+			return kNSpRC_SendFailed;						// hard error
+		}
+
+		// EWOULDBLOCK: fall through and queue the whole message.
+	}
+
+	return SendRing_Append(ring, (const uint8_t*)header, msgLen)
+		? kNSpRC_OK : kNSpRC_SendFailed;					// false == overflow -> caller's kick / terminate path
+}
+
+// Drains each socket's send ring with non-blocking send()s. Called every Net_Pump (frame
+// start + inside the Stage-1 blocking receive loops). Host: a drain failure kicks that one
+// client (the kick's PlayerLeft broadcast only appends into OTHER slots' rings). Client:
+// a failure closes the uplink so the existing PollSocket broken-pipe path synthesizes
+// kNSpGameTerminated(NetworkError) — no NetLow->NetHigh fatal-call dependency.
+void NSpGame_FlushSends(NSpGameReference gameRef)
+{
+	NSpGame* game = NSpGame_Unbox(gameRef);
+
+	if (!game)
+	{
+		return;
+	}
+
+	if (game->isHosting)
+	{
+		for (int i = 0; i < MAX_CLIENTS; i++)
+		{
+			NSpPlayer* peer = &game->players[i];
+
+			if (!IsSocketValid(peer->sockfd))
+			{
+				SendRing_Reset(&peer->sendRing);
+				continue;
+			}
+
+			if (SendRing_Drain(&peer->sendRing, peer->sockfd) != kNSpRC_OK)
+			{
+				// Do NOT NSpPlayer_Kick directly here: that would clear the slot + tell the OTHER
+				// clients, but never run PlayerUnexpectedlyLeavesGame on the host itself (this is a
+				// send path, not the message-get path). Host and clients would then disagree on
+				// isComputer -> divergent synced-RNG draw counts -> randomSeed desync FATAL. Defer:
+				// the next NSpMessage_GetAsHost hands the host's own NetHigh the kNSpPlayerLeft.
+				NSpPlayer_DeferLeaveNotify(peer);
+			}
+		}
+	}
+	else
+	{
+		if (IsSocketValid(game->clientToHostSocket))
+		{
+			if (SendRing_Drain(&game->clientSendRing, game->clientToHostSocket) != kNSpRC_OK)
+			{
+				CloseSocket(&game->clientToHostSocket);		// next NSpMessage_Get -> kNSpGameTerminated
+				SendRing_Reset(&game->clientSendRing);
+			}
+		}
+	}
+}
+
 // Attempts to send a message.
 // If we're the host and sending fails, automatically kicks the client.
 // Kicking the client will in turn broadcast a PlayerLeftMessage to remaining clients,
@@ -1831,7 +2080,6 @@ int NSpMessage_Send(NSpGameReference gameRef, NSpMessageHeader* header, int flag
 		{
 			case kNSpAllPlayers:
 			{
-				int anyError = 0;
 				for (int i = 0; i < MAX_CLIENTS; i++)
 				{
 					NSpPlayer* peer = &game->players[i];
@@ -1839,16 +2087,20 @@ int NSpMessage_Send(NSpGameReference gameRef, NSpMessageHeader* header, int flag
 					if (peer->state == kNSpPlayerState_ConnectedPeer	// send to peers with complete handshake
 						&& peer->id != header->from)					// don't return to sender!
 					{
-						int rc = SendOnSocket(game->players[i].sockfd, header);
+						int rc = SendOrEnqueue(peer->sockfd, &peer->sendRing, header);
 						if (rc != kNSpRC_OK && kickOnFail)
 						{
-							anyError = rc;
-							NSpPlayerID kickedPlayerID = NSpGame_ClientSlotToID(gameRef, i);
-							NSpPlayer_Kick(gameRef, kickedPlayerID);
+							// A single slow/dead peer is RESOLVED by dropping that one peer (the
+							// deferred leave path notifies the host's own NetHigh + the other
+							// clients). It must NOT bubble up as the broadcast's return value:
+							// HostSend_ControlInfoToClients fatals the WHOLE session on a non-zero
+							// return, so one overflowing client would otherwise nuke everyone.
+							NSpPlayer_DeferLeaveNotify(peer);
 						}
 					}
 				}
-				return anyError;
+				// Per-peer failures are handled by the kick above; the broadcast as a whole succeeds.
+				return kNSpRC_OK;
 			}
 
 			case kNSpHostID:
@@ -1864,10 +2116,12 @@ int NSpMessage_Send(NSpGameReference gameRef, NSpMessageHeader* header, int flag
 					&& (peer->state == kNSpPlayerState_ConnectedPeer
 						|| peer->state == kNSpPlayerState_AwaitingHandshake))
 				{
-					int rc = SendOnSocket(peer->sockfd, header);
+					int rc = SendOrEnqueue(peer->sockfd, &peer->sendRing, header);
 					if (rc != kNSpRC_OK && kickOnFail)
 					{
-						NSpPlayer_Kick(gameRef, playerID);
+						// Defer the kick so the host's own NetHigh is notified of the departure at
+						// the same logical point the remote clients are (see NSpMessage_GetAsHost).
+						NSpPlayer_DeferLeaveNotify(peer);
 					}
 					return rc;
 				}
@@ -1883,11 +2137,14 @@ int NSpMessage_Send(NSpGameReference gameRef, NSpMessageHeader* header, int flag
 		// If we're a client, forward ALL messages to the host.
 		// The host will dispatch the message for us.
 
-		int rc = SendOnSocket(game->clientToHostSocket, header);
+		int rc = SendOrEnqueue(game->clientToHostSocket, &game->clientSendRing, header);
 		if (rc != kNSpRC_OK)
 		{
-			// TODO: Client couldn't send a message to the host! Kill the game?
-			puts("Client couldn't send a message to the host! Kill the game?");
+			// Ring overflow or hard socket error: tear down the uplink so the next
+			// NSpMessage_Get synthesizes kNSpGameTerminated(NetworkError) through the
+			// existing broken-pipe path (no NetLow->NetHigh fatal-call dependency).
+			CloseSocket(&game->clientToHostSocket);
+			SendRing_Reset(&game->clientSendRing);
 		}
 
 		return rc;
@@ -1895,6 +2152,19 @@ int NSpMessage_Send(NSpGameReference gameRef, NSpMessageHeader* header, int flag
 }
 
 #pragma mark - NSpCMRClient
+
+// Host-side: a send to this peer just failed (ring overflow ~2s backlog, or a hard socket
+// error). We are on a send path, NOT the message-get path, so we cannot hand the host's own
+// NetHigh a kNSpPlayerLeft from here. Defer it: drop the socket and flag the slot. The next
+// NSpMessage_GetAsHost synthesizes the local kNSpPlayerLeft (running PlayerUnexpectedlyLeavesGame
+// in lockstep with the remote clients) and broadcasts the leave to the other clients via
+// NSpPlayer_Kick. This keeps host vs client agreement on isComputer / gNumGatheredPlayers and the
+// synced-RNG draw count, which a direct NSpPlayer_Kick from a send path would break.
+static void NSpPlayer_DeferLeaveNotify(NSpPlayer* peer)
+{
+	peer->needsLeaveNotify = true;
+	CloseSocket(&peer->sockfd);		// no further send()/recv() on this dead peer; flag drives cleanup
+}
 
 int NSpPlayer_Kick(NSpGameReference gameRef, NSpPlayerID kickedPlayerID)
 {

--- a/Source/Player/Player_Submarine.c
+++ b/Source/Player/Player_Submarine.c
@@ -605,7 +605,11 @@ static float    sideForce[MAX_PLAYERS] = {0};       // Persistent sideways force
 		float sidewaysforce_update = 1.0f; // How often the sub has its x-axis direction reassigned while stuck
         if ((int)(stuckTimer[player] * sidewaysforce_update) != (int)((stuckTimer[player] - fps) * sidewaysforce_update)) // Update sideways force every second
         {
-            sideForce[player] = (VisualRandomLong() & 1) ? 1.0f : -1.0f; // randomly assign either full left or full right directional movement
+            // sideForce feeds analogSteering.x (a sim path -> car position), so it must not
+            // come from the unsynced VisualRandom stream. Use stateless ChaoticFloat keyed on
+            // the stuck timer + player slot: no synced-stream draw, but the left/right choice
+            // no longer diverges per-machine.
+            sideForce[player] = (ChaoticFloat(stuckTimer[player], player) < 0.5f) ? 1.0f : -1.0f; // randomly assign either full left or full right directional movement
         }
 
 		// Try to get unstuck 

--- a/Source/Player/Player_Weapons.c
+++ b/Source/Player/Player_Weapons.c
@@ -1857,8 +1857,11 @@ Boolean DoTrig_LandMine(ObjNode *theNode, ObjNode *whoNode, Byte sideBits)
 
 		/* MAKE CAR SPIN WILDLY */
 
-	whoNode->DeltaRot.y = VisualRandomFloat2() * 20.0f;
-	whoNode->DeltaRot.z = VisualRandomFloat2() * 10.0f;
+	// DeltaRot integrates into the car's Rot/heading (sim path), so use stateless ChaoticFloat
+	// keyed on car speed + player slot instead of the unsynced VisualRandom stream. Same pattern
+	// as the cactus spin fix: VisualRandomFloat2()*S == (ChaoticFloat-0.5)*2*S, centered.
+	whoNode->DeltaRot.y = (ChaoticFloat(whoNode->Speed3D, whoNode->PlayerNum) - 0.5f) * 2.0f * 20.0f;
+	whoNode->DeltaRot.z = (ChaoticFloat(whoNode->Speed3D, whoNode->PlayerNum + 10) - 0.5f) * 2.0f * 10.0f;
 
 
 		/* MAKE EXPLOSION */

--- a/Source/Screens/Paused.c
+++ b/Source/Screens/Paused.c
@@ -141,31 +141,70 @@ void OnToggleSplitscreenMode(const MenuItem* mi)
 
 static void UpdatePausedMenuCallback(void)
 {
+			/* CMR7 CLIENT-INITIATED PAUSE: STAY IN LOCKSTEP UNTIL THE HOST CONFIRMS THE PAUSE */
+	//
+	// The host never waits (free-running Net_Pump + Host_ConsumeClientInputs). If a pausing
+	// client froze its sim immediately, the host would keep advancing MoveEverything for the
+	// whole uplink round-trip while the client did not — so the per-frame seed check
+	// (MyRandomLong() vs the host's broadcast seed) would diverge within ~2 packets and fire a
+	// kNetSequence_SeedDesync FATAL. Instead, mirror the Main.c game loop here: consume the
+	// host packet, then advance the sim normally while the host is still running, and only
+	// switch to the frozen (MoveObjects-only) branch once the host's broadcast itself reports
+	// the net pause. We re-assert our own pauseState each iteration so the host latches the
+	// pause (ClientReceive overwrites our local copy with the host's lagging view).
+
+	if (gNetGameInProgress && gIsNetworkClient)
+	{
+		ClientReceive_ControlInfoFromHost();
+
+		// The receive can tear the net game down (e.g. the host left -> EndNetworkGame
+		// clears gIsNetworkClient). Don't send into a dead session: ClientSend asserts
+		// gIsNetworkClient and would crash both this client's process.
+		if (!gIsNetworkClient || !gNetGameInProgress)
+			return;
+
+		// Evaluate BEFORE re-asserting our own intent below, so this reflects ONLY the host's
+		// (just-received) broadcast — i.e. whether the host has actually begun the net pause.
+		Boolean hostConfirmedPause = IsNetGamePaused();
+
+		if (hostConfirmedPause)
+		{
+			gSimulationPaused = true;
+			MoveObjects();								// frozen step — host is running MoveObjects too
+			DoPlayerTerrainUpdate();
+		}
+		else
+		{
+			gSimulationPaused = false;
+			MoveEverything();							// stay in lockstep: same RNG draw count as the host
+			UpdateGameModeSpecifics();
+			DoPlayerTerrainUpdate();
+			gSimulationFrame++;
+		}
+
+		// Re-assert our local pause intent (the menu is open) so the host latches & broadcasts
+		// the net pause; ClientReceive just clobbered our copy with the host's lagging view.
+		gPlayerInfo[gMyNetworkPlayerNum].net.pauseState = 1;
+		ClientSend_ControlInfoToHost();
+		return;
+	}
+
 	MoveObjects();
 	DoPlayerTerrainUpdate();							// need to call this to keep supertiles active
 
 
 			/* IF DOING NET GAME, LET OTHER PLAYERS KNOW WE'RE STILL GOING SO THEY DONT TIME OUT */
 
-	if (gNetGameInProgress)
+	if (gNetGameInProgress && gIsNetworkHost)
 	{
-		// Burn one net frame
-		if (gIsNetworkClient)
-		{
-			ClientReceive_ControlInfoFromHost();
-			// The receive can tear the net game down (e.g. the host left -> EndNetworkGame
-			// clears gIsNetworkClient). Don't send into a dead session: ClientSend asserts
-			// gIsNetworkClient and would crash both this client's process.
-			if (gIsNetworkClient && gNetGameInProgress)
-				ClientSend_ControlInfoToHost();
-		}
-		else if (gIsNetworkHost)
-		{
+		// CMR7: the host never blocks — drain client inputs (non-blocking), resolve them
+		// (substitute/coalesce), then broadcast, keeping the full-rate lockstep alive while
+		// the pause menu is open.
+		Net_Pump();
+		Host_ConsumeClientInputs();
+		// A send failure can call NetGameFatalError -> EndNetworkGame (clears gIsNetworkHost).
+		if (gIsNetworkHost && gNetGameInProgress)
 			HostSend_ControlInfoToClients();
-			// A send failure can call NetGameFatalError -> EndNetworkGame (clears gIsNetworkHost).
-			if (gIsNetworkHost && gNetGameInProgress)
-				HostReceive_ControlInfoFromClients();
-		}
 	}
 }
 

--- a/Source/Screens/SelectVehicle.c
+++ b/Source/Screens/SelectVehicle.c
@@ -88,7 +88,12 @@ Boolean DoMultiPlayerVehicleSelections(void)
 		}
 
 		PlayerBroadcastVehicleType();								// tell other net players about my type
-		GetVehicleSelectionFromNetPlayers();						// get types from other net players
+
+		// Propagate an abort/teardown that happens while waiting for the other net players'
+		// vehicle selections, so we bail cleanly instead of starting a broken split-screen match.
+		if (GetVehicleSelectionFromNetPlayers())					// get types from other net players
+			return true;											// aborted / net game torn down
+
 		return false;
 	}
 	else

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -42,7 +42,7 @@ static Boolean PlayGame_Tournament(void);
 static Boolean PlayGame_Tag(void);
 static Boolean PlayGame_Survival(void);
 static Boolean PlayGame_CaptureTheFlag(void);
-static void UpdateGameModeSpecifics(void);
+void UpdateGameModeSpecifics(void);
 
 static void TallyTokens(void);
 
@@ -1001,20 +1001,20 @@ static void PlayArea(void)
 	//==========================================================================
 
 	//
-	// WIFI JITTER FIX: CLIENT PRE-ROLL
-	// Send a burst of initial input packets to fill the Host's OS buffer.
-	// This prevents the Host from stalling (stuttering) if packets arrive with jitter.
+	// CMR7: replace the old ~500ms 30-frame pre-roll with D_init duplicate input packets.
+	// The client banks D_init REAL packets in the host's per-client queue so the very first
+	// consumed frame is real (wired seeds 2, WiFi seeds 6); each duplicate increments
+	// gClientSendCounter[me]. The host seeds its per-client adaptive depth to match.
 	//
-	if (gIsNetworkClient && gUseRedundancy)
+	if (gIsNetworkClient)
 	{
-		int framesToBuffer = 30;
-		if (gTargetFPS > 0)
-			framesToBuffer = (30 * gTargetFPS) / 60;
-
-		for (int i = 0; i < framesToBuffer; i++) // Scaled buffer to ~500ms equivalent
-		{
+		int dinit = (Net_GetConnectionHint() == 1) ? 6 : 2;
+		for (int i = 0; i < dinit; i++)
 			ClientSend_ControlInfoToHost();
-		}
+	}
+	else if (gIsNetworkHost)
+	{
+		Host_InitInputControl();				// seed per-client adaptive input-queue depth D_init
 	}
 
 	MakeFadeEvent(true);
@@ -1039,11 +1039,16 @@ static void PlayArea(void)
 		{
 			// Clients MUST wait for the Host's packet (Lockstep)
 			// This blocks until the packet for this frame arrives.
+			// (Stage 2 keeps this blocking shim; Stage 3 makes the client free-running.)
 			ClientReceive_ControlInfoFromHost();
 		}
 		else
 		{
-			// Host must send the inputs for THIS frame before simulation
+			// CMR7 host frame: drain client inputs (non-blocking), resolve THIS frame's
+			// per-client input (substitute/coalesce — the host NEVER waits on a radio), then
+			// broadcast — all before simulation.
+			Net_Pump();
+			Host_ConsumeClientInputs();
 			HostSend_ControlInfoToClients();
 		}
 
@@ -1072,17 +1077,29 @@ static void PlayArea(void)
 
 
 		//
-		// 3. SEND CLIENT INPUT (For NEXT frame)
+		// 3. READ LOCAL INPUT (For NEXT frame) / SEND CLIENT INPUT
 		//
 		if (gNetGameInProgress)
 		{
-			ReadKeyboard();
-			GetLocalKeyState();
-			schedulePause = GetNewNeedStateAnyP(kNeed_UIPause);
-			gPlayerInfo[gMyNetworkPlayerNum].net.pauseState = schedulePause;
+			schedulePause = false;
 
 			if (gIsNetworkClient)
-				ClientSend_ControlInfoToHost();
+			{
+				// CMR7 (G1): wall-clock-paced sampler — the uplink cadence is decoupled from
+				// host-packet receipt, so a downlink stall never silences the uplink. It reads
+				// local input and sends one (or a small catch-up burst of) input packet(s).
+				SampleAndSendLocalInput(&schedulePause);
+				Net_Pump();									// flush the just-enqueued input packets
+			}
+			else
+			{
+				// Host reads its own input here for the NEXT frame (~1F latency preserved).
+				ReadKeyboard();
+				GetLocalKeyState();
+				if (GetNewNeedStateAnyP(kNeed_UIPause))
+					schedulePause = true;
+				gPlayerInfo[gMyNetworkPlayerNum].net.pauseState = schedulePause;
+			}
 		}
 
 
@@ -1113,18 +1130,9 @@ static void PlayArea(void)
 		}
 
 
-			/************************************/
-			/* NET HOST RECEIVE CLIENT KEY INFO */
-			/************************************/
-			//
-			// Odds are that the clients have all sent their control into to the Host by now,
-			// so the Host can read all of the client key info for use on the next frame.
-			//
-
-		if (gIsNetworkHost)
-		{
-			HostReceive_ControlInfoFromClients();		// get client info
-		}
+			// CMR7: the end-of-frame blocking HostReceive_ControlInfoFromClients() is DELETED.
+			// Host input intake now happens at top-of-frame via Net_Pump + Host_ConsumeClientInputs,
+			// so the host never blocks on any client's radio.
 
 
 			/**************/
@@ -1560,7 +1568,7 @@ static void CleanupLevel(void)
 
 /*************** UPDATE GAME MODE SPECIFICS **********************/
 
-static void UpdateGameModeSpecifics(void)
+void UpdateGameModeSpecifics(void)
 {
 short	i,t,winner;
 

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -1024,6 +1024,8 @@ static void PlayArea(void)
 	{
 		uint64_t startTick = SDL_GetPerformanceCounter();
 
+		Net_Pump();						// Stage 1: drain non-blocking send rings (cheap no-op outside net games)
+
 		//
 		// 1. INPUT & NETWORK SYNC
 		//

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -44,6 +44,8 @@ static Boolean PlayGame_Survival(void);
 static Boolean PlayGame_CaptureTheFlag(void);
 void UpdateGameModeSpecifics(void);
 
+static void StepGameSimulation(void);			// CMR7 Stage 3: one sim step (host/SP run once; client runs 0..K_max)
+
 static void TallyTokens(void);
 
 
@@ -59,6 +61,8 @@ static void TallyTokens(void);
 
 Byte				gDebugMode = 0;				// 0 == none, 1 = fps, 2 = all
 Boolean				gIsInGame = false;
+
+int					gClientCatchUpMax = 3;		// CMR7 Stage 3: client bounded catch-up K_max per render frame (weakest-Android fallback 2)
 
 uint32_t				gAutoFadeStatusBits;
 
@@ -955,6 +959,36 @@ static void CheckCheats(void)
 
 /**************** PLAY AREA ************************/
 
+/********************* STEP GAME SIMULATION **********************/
+//
+// One simulation step. CMR7 Stage 3 factors this out of the PlayArea inner loop so the
+// free-running client can run it 0..gClientCatchUpMax times per render frame (host and
+// single-player still run it exactly once). Behaviour is identical to the old inline block.
+//
+
+static void StepGameSimulation(void)
+{
+	if (IsNetGamePaused())
+	{
+		gSimulationPaused = true;
+		SetupNetPauseScreen();
+		MoveObjects();
+		DoPlayerTerrainUpdate();
+	}
+	else
+	{
+		gSimulationPaused = false;
+		RemoveNetPauseScreen();
+
+		MoveEverything();
+		UpdateGameModeSpecifics();
+		DoPlayerTerrainUpdate();
+
+		gSimulationFrame++;
+	}
+}
+
+
 static void PlayArea(void)
 {
 	Boolean schedulePause = false;
@@ -1027,20 +1061,46 @@ static void PlayArea(void)
 		Net_Pump();						// Stage 1: drain non-blocking send rings (cheap no-op outside net games)
 
 		//
-		// 1. INPUT & NETWORK SYNC
+		// 1. INPUT / NETWORK SYNC  +  2. SIMULATION
+		//
+		// Single-player and the host run exactly one sim step per render frame. The CMR7
+		// client is free-running (Stage 3): Net_Pump drains host packets into the ring, then
+		// it consumes up to gClientCatchUpMax this frame, stepping the sim once per applied
+		// packet (each replays its own host dt for a bit-identical trajectory). An empty ring
+		// => hold-last-frame: the unconditional render at Step 4 re-presents the prior image.
 		//
 		if (!gNetGameInProgress)
 		{
 			ReadKeyboard();									// read local keys
 			GetLocalKeyState();								// build a control state bitfield
 			schedulePause = GetNewNeedStateAnyP(kNeed_UIPause);
+
+			StepGameSimulation();
 		}
 		else if (gIsNetworkClient)
 		{
-			// Clients MUST wait for the Host's packet (Lockstep)
-			// This blocks until the packet for this frame arrives.
-			// (Stage 2 keeps this blocking shim; Stage 3 makes the client free-running.)
-			ClientReceive_ControlInfoFromHost();
+			Net_Pump();										// flush send rings + drain host packets into the ring
+
+			int guard = 0;
+			for (int k = 0; k < gClientCatchUpMax; )		// bounded catch-up (K_max)
+			{
+				HostConsumeResult r = Client_ConsumeHostPacketFromRing();
+				if (r == kHostConsume_Applied)
+				{
+					StepGameSimulation();					// one sim step per applied host packet
+					k++;
+				}
+				else if (r == kHostConsume_Dup)
+				{
+					if (++guard > 2*gClientCatchUpMax)		// defense vs a pathological dup storm
+						break;
+					// duplicate: no sim step, do not burn a k-slot
+				}
+				else
+				{
+					break;									// kHostConsume_Empty -> hold-last-frame this render frame
+				}
+			}
 		}
 		else
 		{
@@ -1050,29 +1110,8 @@ static void PlayArea(void)
 			Net_Pump();
 			Host_ConsumeClientInputs();
 			HostSend_ControlInfoToClients();
-		}
 
-
-		//
-		// 2. SIMULATION
-		//
-		if (IsNetGamePaused())
-		{
-			gSimulationPaused = true;
-			SetupNetPauseScreen();
-			MoveObjects();
-			DoPlayerTerrainUpdate();
-		}
-		else
-		{
-			gSimulationPaused = false;
-			RemoveNetPauseScreen();
-
-			MoveEverything();
-			UpdateGameModeSpecifics();
-			DoPlayerTerrainUpdate();
-
-			gSimulationFrame++;
+			StepGameSimulation();
 		}
 
 

--- a/Source/System/Misc.c
+++ b/Source/System/Misc.c
@@ -12,6 +12,7 @@
 #include "game.h"
 #include "network.h"
 #include <time.h>
+#include <string.h>
 
 extern	SDL_Window* 	gSDLWindow;
 
@@ -242,7 +243,13 @@ void InitMyRandomSeed(void)
 //
 float ChaoticFloat(float seedVal, int modifier)
 {
-	uint32_t h = (uint32_t)(seedVal * 10.0f);
+	// Reinterpret the IEEE-754 bit pattern rather than value-truncating the cast. Casting a
+	// negative float to uint32_t is UB (C11 6.3.1.4) and diverges across targets (AArch64 fcvtzu
+	// saturates to 0, x86 cvttss2si wraps), which desyncs peers when seedVal is a negative
+	// (off-map) coordinate. memcpy of the bit pattern is well-defined for all finite inputs and
+	// identical across all targets.
+	uint32_t h;
+	memcpy(&h, &seedVal, sizeof h);
 	h ^= gSimulationFrame; 			// Time varying
 	h += modifier;
 	h *= 0x85ebca6b;				


### PR DESCRIPTION
## Summary

Implements the **CMR7 "Free-Running Lockstep" WiFi netcode redesign** — the core of
making WiFi LAN play as smooth as wired without an unacceptable latency cost. Built
stage-by-stage, each stage build-verified and run through an adversarial review panel,
then the combined diff through a cross-stage integration review.

Stacked on #1 (the P0/P1 fixes are its foundation). **The full game builds clean from
scratch** (`build.py --dependencies --configure --build`).

## What's here

- **Stage 0r** — the determinism fixes deferred from #1: the remaining position/collision-
  gated RNG draws moved to stateless `ChaoticFloat` (zero added seed-check draws), the
  sync-mask `playerNum`/`NSpPlayerID` conflation, everybody-left, and the vehicle-select
  abort.
- **Stage 1** — non-blocking per-socket send rings, replacing the ~200ms `SendOnSocket`
  main-thread stalls.
- **Stage 2** — the headline: `CMR6→CMR7` protocol bump and a **host that never blocks**
  (input substitution + coalescing with host-derived edges + per-client adaptive input
  delay + a wall-clock-paced client sender). A 656-line rewrite of the host receive path.
- **Stage 3** — client free-running receive: a host-packet ring with bounded catch-up
  (each replayed with its own dt for bit-identical trajectories) and hold-last-frame.
- **Integration-review fixes** — stale-discard off-by-one, a client-side length guard, a
  teardown break, and two missing `_Static_assert` ABI guards.

## Confidence & what still needs a real play-test

The integration review (4 adversarial lenses, weighted toward the per-frame fatal
seed-check) found **no build break, no live crash, and no guaranteed/likely desync**. The
determinism model is sound: relayed `kNSpPlayerLeft` is applied in exact host-stream order
through the client ring so the one conditional synced draw lands at the same stream
position on every peer.

**Honest caveats — do NOT trust these for an open/cross-platform match until a LAN
play-test exercises them**, all addressed by the in-progress Stage 4:
- **Tag-mode mid-race leave**: `ChooseTaggedPlayer`'s synced draw is gated on `isIt[leaver]`,
  which could diverge under cross-platform float non-determinism. Stage 4's frame-aligned
  `kEvBecomeBot` event (wire fields already present, `eventCount=0` until then) makes it
  host-authoritative.
- **Client pause on lossy WiFi** reverts to the blocking receive shim (feel/visibility, plus
  a retained timeout) — Stage 4 mirrors the free-running loop into the pause path.
- **Adaptive depth controller under real jitter** — inherently play-test-only.

For a homogeneous-binary LAN **race** (non-tag), this is safe to start testing now.

Design and per-stage implementation detail: `docs/WIFI-NETCODE-CMR7.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
