### PR TITLE
Fix macOS/Arch/Flatpak release jobs (follow-up to #4)

### DIFF
--- a/build.py
+++ b/build.py
@@ -342,7 +342,10 @@ class MacProject(Project):
             shutil.copytree(f"{mount_point}/{sdl3_framework}", sdl3_framework_target_path, symlinks=True)
             call(["hdiutil", "detach", mount_point, "-quiet"])
 
-        if "CODE_SIGN_IDENTITY" in os.environ:
+        # Check the value, not just presence: CI sets CODE_SIGN_IDENTITY to a (possibly empty)
+        # secret, and signing with an empty identity fails ("item could not be found in the
+        # keychain"). An empty/unset value means "don't sign" -> produce an unsigned build.
+        if os.environ.get("CODE_SIGN_IDENTITY"):
             call(["codesign", "--force", "--timestamp", "--sign", os.environ["CODE_SIGN_IDENTITY"], sdl3_framework_target_path])
         else:
             print("SDL will not be codesigned. Set the CODE_SIGN_IDENTITY environment variable if you want to sign it.")

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -16,7 +16,9 @@ url="https://github.com/jorio/CroMagRally"
 license=('CC-BY-NC-SA-4.0')
 depends=('sdl3' 'libglvnd' 'hicolor-icon-theme')
 makedepends=('cmake' 'ninja' 'git')
-options=('!lto')          # keep floating-point behavior predictable (pairs with -ffp-contract=off)
+options=('!lto' '!debug') # !lto keeps FP behavior predictable (pairs with -ffp-contract=off);
+                          # !debug stops makepkg emitting a second cromagrally-debug package
+                          # (two .pkg.tar.zst would break the single-file copy in CI)
 source=()                 # built in-tree from $startdir; submodules must already be populated
 
 build() {

--- a/packaging/flatpak/io.jor.cromagrally.yml
+++ b/packaging/flatpak/io.jor.cromagrally.yml
@@ -18,9 +18,8 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc               # X11 shared-memory
-  - --device=dri              # OpenGL acceleration
-  - --device=input            # game controllers (/dev/input/event*); use --device=all if a
-                              # hidraw-only pad (some PlayStation/Switch controllers) misbehaves
+  - --device=all              # OpenGL (dri) + game controllers; this flatpak has no granular
+                              # 'input' device type (valid types are dri, all, kvm, shm)
   - --socket=pulseaudio
   - --share=network           # LAN / Wi-Fi netplay (TCP+UDP, default port 49959)
 


### PR DESCRIPTION
Follow-up to #4. The first full `workflow_dispatch` run ([27494592742](https://github.com/jm2/CroMagRally/actions/runs/27494592742)) proved **deb, rpm, AppImage, Android, Windows, iOS, tvOS and checksums all pass** (both x86_64 and aarch64). It surfaced three remaining bugs, fixed here:

- **macOS** — `build.py` codesigned the bundled SDL framework whenever `CODE_SIGN_IDENTITY` was *present* in the env, but CI sets it to a possibly-empty secret → `codesign --sign ""` → *"item could not be found in the keychain."* Now signs only when the value is non-empty (unsigned build otherwise). Pre-existing latent bug that gating the cert-import step in #4 exposed.
- **Arch** — the package built fine, but makepkg also emits a `cromagrally-debug` package, so `*.pkg.tar.zst` matched two files and the single-file `cp` failed. Added `!debug`.
- **Flatpak** — SDL + game built and the metainfo composed successfully, then `--device=input` errored (*valid types: dri, all, kvm, shm*). Switched to `--device=all` (covers OpenGL + controllers).

After merge, re-run the dispatch to confirm all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)