### PR TITLE
Fix validated holistic review findings

### DIFF
--- a/.github/workflows/FullCompileCheck.yml
+++ b/.github/workflows/FullCompileCheck.yml
@@ -1,7 +1,8 @@
 name: Full Compile Check
 
 # Run automatically on pull requests and pushes to master so compile breakage is caught
-# in CI (Linux GCC/Clang, Windows VS2022, macOS), plus manual dispatch for ad-hoc checks.
+# in CI (Linux x86_64/ARM64, Windows VS2022, macOS, Apple mobile and Android), plus
+# manual dispatch for ad-hoc checks.
 on:
   workflow_dispatch:
   pull_request:
@@ -18,8 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: Linux/GCC, os: ubuntu-latest }
+          # The GCC job also exercises the common CPack/FHS install path with DEB and RPM.
+          - { name: Linux/GCC, os: ubuntu-latest, packageflags: "--deb" }
           - { name: Linux/Clang, os: ubuntu-latest, prefix: "CC=clang CXX=clang++"}
+          - { name: Linux/ARM64, os: ubuntu-24.04-arm }
           - { name: Windows/VS2022, os: windows-2022, extraflags: "-G 'Visual Studio 17 2022'" }
           - { name: Mac, os: macos-latest }
 
@@ -40,19 +43,31 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with: {submodules: 'recursive'}
 
-      - run: ${{matrix.platform.prefix}} python3 build.py --dependencies --configure --build ${{matrix.platform.extraflags}}
+      - name: Install RPM packaging tool
+        if: matrix.platform.name == 'Linux/GCC'
+        run: sudo apt install -y rpm
+
+      - run: ${{matrix.platform.prefix}} python3 build.py --dependencies --configure --build ${{matrix.platform.packageflags}} ${{matrix.platform.extraflags}}
+
+      - name: Verify native Linux packages
+        if: matrix.platform.name == 'Linux/GCC'
+        run: |
+          test -s ../dist/*.deb
+          cpack -G RPM --config CPackConfig.cmake
+          test -s ./*.rpm
+        working-directory: build
 
       - name: Run validation tests (Linux)
         if: runner.os == 'Linux'
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure --no-tests=error
 
       - name: Run validation tests (Windows)
         if: runner.os == 'Windows'
-        run: ctest --test-dir build --build-config Release --output-on-failure
+        run: ctest --test-dir build --build-config Release --output-on-failure --no-tests=error
 
       - name: Run validation tests (macOS)
         if: runner.os == 'macOS'
-        run: ctest --test-dir build --build-config RelWithDebInfo --output-on-failure
+        run: ctest --test-dir build --build-config RelWithDebInfo --output-on-failure --no-tests=error
 
       - name: Configure sanitizer validation tests
         if: matrix.platform.name == 'Linux/GCC'
@@ -62,7 +77,37 @@ jobs:
         if: matrix.platform.name == 'Linux/GCC'
         run: |
           cmake --build build-sanitize --target CroMagRallyValidationTests PommeFileTests PommeIEEEExtendedTests --parallel 2
-          ctest --test-dir build-sanitize --output-on-failure
+          ctest --test-dir build-sanitize --output-on-failure --no-tests=error
+
+  # Compile the exact unsigned ARM64 device targets used by the release workflow. Running
+  # the developer scripts catches SDK, bundle, SDL static-link and mobile CMake regressions;
+  # packaging/signing stays in ReleaseBuilds.yml.
+  apple-mobile-check:
+    name: Apple mobile (${{ matrix.target.name }})
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { name: iOS, script: build_ios.sh }
+          - { name: tvOS, script: build_tvos.sh }
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with: {submodules: 'recursive'}
+
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Compile unsigned ${{ matrix.target.name }} device app
+        env:
+          CODE_SIGNING_ALLOWED: "NO"
+        run: ./${{ matrix.target.script }} device
+
+  # Arch/Flatpak and Windows ARM64 remain release gates: each needs its own full build
+  # environment and would duplicate the expensive SDL/game compile. Linux ARM64 covers
+  # native ARM code generation here, while DEB+RPM cover the shared CPack/FHS package path.
 
   # The desktop matrix above can't catch breakage in the Android NDK build or the mobile
   # branches of the shared CMakeLists, which otherwise only surface at release-tag time.

--- a/AndroidBuild/app/build.gradle
+++ b/AndroidBuild/app/build.gradle
@@ -112,3 +112,59 @@ tasks.register('verifySdlJavaGlue') {
 tasks.named('preBuild').configure {
     dependsOn tasks.named('verifySdlJavaGlue')
 }
+
+def stagedAssetsDir = file('src/main/assets')
+def stagedJniLibsDir = file('src/main/jniLibs')
+def verifyStagedPackageInputs = tasks.register('verifyStagedPackageInputs') {
+    group = 'verification'
+    description = 'Checks that the native libraries and game assets were staged by the repository build wrapper.'
+
+    // This task intentionally has no mandatory Gradle file inputs.  It must run
+    // even when the generated staging directories do not exist so it can emit an
+    // actionable error instead of Gradle's generic missing-input diagnostic.
+    doLast {
+        def missing = []
+        [
+            new File(stagedAssetsDir, 'Data/files.txt'),
+            new File(stagedAssetsDir, 'Data/System/gamecontrollerdb.txt'),
+            new File(stagedAssetsDir, 'LICENSE.md'),
+            new File(stagedAssetsDir, 'THIRD-PARTY-LICENSES.md'),
+        ].each { requiredFile ->
+            if (!requiredFile.isFile() || requiredFile.length() == 0) {
+                missing << project.relativePath(requiredFile)
+            }
+        }
+
+        def stagedAbis = stagedJniLibsDir.isDirectory()
+            ? (stagedJniLibsDir.listFiles() ?: []).findAll { it.isDirectory() }.sort { it.name }
+            : []
+        if (stagedAbis.isEmpty()) {
+            missing << "${project.relativePath(stagedJniLibsDir)}/<ABI>/{libmain.so,libSDL3.so}"
+        } else {
+            stagedAbis.each { abiDir ->
+                ['libmain.so', 'libSDL3.so'].each { libraryName ->
+                    def library = new File(abiDir, libraryName)
+                    if (!library.isFile() || library.length() == 0) {
+                        missing << project.relativePath(library)
+                    }
+                }
+            }
+        }
+
+        if (!missing.isEmpty()) {
+            throw new GradleException(
+                "Android package inputs have not been staged by the repository build wrapper. " +
+                "Run build_android.sh (or build_android.ps1) from the repository root. " +
+                "Missing or empty: ${missing.join(', ')}")
+        }
+    }
+}
+
+// Packaging consumes generated source-tree directories that are deliberately
+// gitignored.  Put the check immediately before AGP snapshots either directory;
+// lint and other non-packaging Gradle tasks remain independently usable.
+tasks.configureEach { task ->
+    if (task.name ==~ /^merge(?:Debug|Release)(?:Assets|JniLibFolders)$/) {
+        task.dependsOn verifyStagedPackageInputs
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,9 @@ if(BUILD_TESTING AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" AND NO
 	add_test(
 		NAME version_metadata
 		COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Tests/VersionMetadataTests.py ${CMAKE_SOURCE_DIR})
+	add_test(
+		NAME localization_data
+		COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Tests/LocalizationDataTests.py ${CMAKE_SOURCE_DIR})
 	if(WIN32)
 		# Keep the runtime-DLL staging hook beside the executable it belongs to so
 		# target existence and directory scope are unambiguous at configure time.

--- a/Source/Boot.cpp
+++ b/Source/Boot.cpp
@@ -223,13 +223,29 @@ static void Boot(int argc, char **argv) {
           if (line.back() == '\r')
             line.pop_back();
 
+          // Normalize once, require a file below the Data directory, and use that
+          // normalized path for both sides of the copy.  Validating one spelling
+          // but passing the raw manifest line to SDL/filesystem APIs would leave a
+          // path-traversal gap between the check and its use.
           fs::path assetPath = fs::path(line).lexically_normal();
-          bool safePath = !assetPath.is_absolute() && line.rfind("Data/", 0) == 0;
-          for (const fs::path &component : assetPath) {
-            if (component == "..") {
-              safePath = false;
-              break;
+          fs::path relativeAssetPath;
+          bool safePath = !line.empty() && line.find('\0') == std::string::npos &&
+                          !assetPath.empty() && !assetPath.is_absolute();
+          auto component = assetPath.begin();
+          if (!safePath || component == assetPath.end() ||
+              *component != fs::path("Data")) {
+            safePath = false;
+          } else {
+            for (++component; component != assetPath.end(); ++component) {
+              if (component->empty() || *component == fs::path(".") ||
+                  *component == fs::path("..")) {
+                safePath = false;
+                break;
+              }
+              relativeAssetPath /= *component;
             }
+            if (relativeAssetPath.empty())
+              safePath = false;
           }
           if (!safePath) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
@@ -238,25 +254,29 @@ static void Boot(int argc, char **argv) {
             break;
           }
 
+          const std::string normalizedAssetPath = assetPath.generic_string();
+
           // Create parent directories
-          fs::path filePath = stagingDir / line.substr(5);
+          fs::path filePath = stagingDir / relativeAssetPath;
           fs::create_directories(filePath.parent_path());
 
           // Copy
           size_t dataSize;
-          void *data = SDL_LoadFile(line.c_str(), &dataSize);
+          void *data = SDL_LoadFile(normalizedAssetPath.c_str(), &dataSize);
           if (data) {
             if (!SDL_SaveFile(
                     reinterpret_cast<const char *>(filePath.u8string().c_str()),
                     data, dataSize)) {
               SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                           "Failed to save extracted asset: %s", line.c_str());
+                           "Failed to save extracted asset: %s",
+                           normalizedAssetPath.c_str());
               extractionOK = false;
             }
             SDL_free(data);
           } else {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                         "Failed to load asset: %s", line.c_str());
+                         "Failed to load asset: %s",
+                         normalizedAssetPath.c_str());
             extractionOK = false;
           }
           if (!extractionOK)

--- a/Source/Headers/net_validation.h
+++ b/Source/Headers/net_validation.h
@@ -14,3 +14,8 @@ Boolean NetValidateConfigPayload(const NetConfigMessage* message);
 Boolean NetValidatePlayerCharPayload(const NetPlayerCharTypeMessage* message, int expectedPlayer, int numRealPlayers);
 Boolean NetValidateClientControlPayload(const NetClientControlInfoMessageType* message, int expectedPlayer, int numRealPlayers);
 Boolean NetValidateHostControlPayload(const NetHostControlInfoMessageType* message, int numRealPlayers);
+
+// Barrier masks are expressed in NSp player-ID space. Bits belonging to players who
+// have since disconnected must not keep an otherwise-complete barrier wedged.
+uint32_t NetRetainActiveSyncBits(uint32_t syncedMask, uint32_t activeMask);
+Boolean NetAreAllActivePlayersSynced(uint32_t syncedMask, uint32_t activeMask);

--- a/Source/Headers/network.h
+++ b/Source/Headers/network.h
@@ -216,6 +216,7 @@ enum
 	kNetSequence_ClientOfflineBecauseHostBailed,
 	kNetSequence_ClientOfflineBecauseHostUnreachable,
 	kNetSequence_ClientOfflineBecauseKicked,
+	kNetSequence_ClientOfflineBecauseJoinDenied,
 	kNetSequence_OfflineEverybodyLeft,
 	kNetSequence_SeedDesync,
 	kNetSequence_PositionDesync,
@@ -228,5 +229,6 @@ enum
 
 
 bool UpdateNetSequence(void);
+const char* Net_GetJoinDeniedReason(void);
 
 Boolean IsNetGamePaused(void);

--- a/Source/Network/NetHigh.c
+++ b/Source/Network/NetHigh.c
@@ -34,7 +34,6 @@
 static OSErr HostSendGameConfigInfo(void);
 static Boolean HandleGameConfigMessage(NetConfigMessage *inMessage);
 static Boolean HandleOtherNetMessage(NSpMessageHeader	*message);
-static Boolean HandleOtherNetMessage(NSpMessageHeader	*message);
 static void PlayerUnexpectedlyLeavesGame(NSpPlayerLeftMessage *mess);
 static int FindHumanByNSpPlayerID(NSpPlayerID playerID);
 int Net_GetConnectionHint(void);
@@ -47,9 +46,10 @@ int Net_GetConnectionHint(void);
 #define LOADING_TIMEOUT	15						// # seconds to wait for clients to load a level
 
 // CMR7 Stage 4: frame-aligned events + connection-liveness policy.
-#define NET_BADGE_MS		1000				// >1s silence from a peer -> connection badge (substitution continues)
-#define NET_DROP_MS			30000				// 30s mobile-background grace before host bot conversion / client error
-#define NET_KEEPALIVE_MS	50					// 20Hz heartbeat throttle (lobby/barriers only; in-game streams 60pps)
+#define NET_BADGE_MS			1000				// >1s silence from a peer -> connection badge (substitution continues)
+#define NET_SILENCE_DROP_MS	5000				// deterministic clients cannot resume missed frames: drop after a short stall
+#define NET_KEEPALIVE_MS		50					// 20Hz heartbeat throttle (lobby/barriers only; in-game streams 60pps)
+#define NET_SEQUENCE_MESSAGE_BUDGET 32			// drain bursts without starving rendering/event processing
 
 /**********************/
 /*     VARIABLES      */
@@ -72,6 +72,9 @@ Str32			gPlayerNameStrings[MAX_PLAYERS];
 
 uint32_t			gClientSendCounter[MAX_PLAYERS];
 uint32_t			gHostSendCounter;
+
+static char			gNetJoinDeniedReason[sizeof(((NSpJoinDeniedMessage*) 0)->reason)] =
+	"THE HOST DENIED THE JOIN REQUEST.";
 
 NetHostControlInfoMessageType	gHostOutMess;
 NetClientControlInfoMessageType	gClientOutMess;
@@ -141,9 +144,16 @@ static inline Boolean IsValidPlayerNum(int n)
 
 static void MarkPlayerSynced(NSpPlayerID playerID)
 {
-	if (playerID < 0 || playerID >= 32)				// 1 << playerID is undefined outside this range
+	if (playerID < kNSpHostID || playerID >= kNSpHostID + MAX_CLIENTS)
 		return;
-	gPlayerSyncMask |= 1 << playerID;
+	gPlayerSyncMask |= 1u << (uint32_t) playerID;
+}
+
+static void ForgetPlayerSync(NSpPlayerID playerID)
+{
+	if (playerID < kNSpHostID || playerID >= kNSpHostID + MAX_CLIENTS)
+		return;
+	gPlayerSyncMask &= ~(1u << (uint32_t) playerID);
 }
 
 // (PlayerIsSynced was only used by the deleted HostReceive busy-spin; the lobby/level-prep
@@ -153,7 +163,8 @@ static Boolean AreAllPlayersSynced(void)
 
 {
 	uint32_t targetMask = NSpGame_GetActivePlayersIDMask(gNetGame);
-	return 0 == (gPlayerSyncMask ^ targetMask);
+	gPlayerSyncMask = NetRetainActiveSyncBits(gPlayerSyncMask, targetMask);
+	return NetAreAllActivePlayersSynced(gPlayerSyncMask, targetMask);
 }
 
 
@@ -381,7 +392,7 @@ static void RecordFrameEvent(uint32_t effectiveFrame, uint8_t type, int8_t playe
 }
 
 // HOST: schedule a frame-aligned event. Deduped against any un-applied (type,playerNum) already in
-// flight so a leave + a >10s drop for the same player don't double-convert. effectiveFrame is the
+// flight so a leave + a silence-timeout drop for the same player don't double-convert. effectiveFrame is the
 // frame ABOUT to be sent (gHostSendCounter) + lead, so all clients receive it before applying.
 static void Host_ScheduleFrameEvent(uint8_t type, int playerNum)
 {
@@ -534,9 +545,10 @@ void ApplyPendingFrameEvents(void)
 //
 // CMR7 Stage 4: per-connection lastHeard policy, replacing the old session-killing 4-strike
 // DATA_TIMEOUT. Called once/frame each role (main loop + pause). >1s silence raises a badge but
-// substitution continues; >10s schedules a frame-aligned become-bot (host) / errors out (client).
-// The TCP keepalive (5s + 3x1s) is the independent dead-peer backstop, surfacing ~8s as a
-// synthesized PlayerLeft/GameTerminated that feeds the same conversion path.
+// substitution continues. A deterministic client cannot resume after missing seconds of host
+// simulation, so sustained silence explicitly schedules a frame-aligned bot conversion and closes
+// that peer instead of claiming a long mobile-background grace that finite send buffers cannot honor.
+// Outbound-ring pressure may detect and drop an unread peer even sooner through the same leave path.
 //
 void NetCheck_ConnectionTimeouts(void)
 {
@@ -560,15 +572,22 @@ void NetCheck_ConnectionTimeouts(void)
 
 			uint32_t dt = now - NSpPlayer_GetLastHeard(gNetGame, pid);
 			gNetBadge[pn] = (dt > NET_BADGE_MS);			// substitution keeps the sim alive regardless
-			if (dt > NET_DROP_MS)
-				Host_ScheduleFrameEvent(kEvBecomeBot, pn);	// deduped; host keeps substituting until effectiveFrame
+			if (dt > NET_SILENCE_DROP_MS)
+			{
+				// Record the deterministic conversion before removing the low-level peer. Remaining
+				// clients ignore the immediate PlayerLeft during gameplay and apply this event from
+				// the ordered host-control stream at the same simulation frame as the host.
+				Host_ScheduleFrameEvent(kEvBecomeBot, pn);
+				NSpPlayer_Kick(gNetGame, pid);
+				break;								// active-player indexing changed; resume next frame
+			}
 		}
 	}
 	else if (gIsNetworkClient)
 	{
 		uint32_t dt = now - NSpGame_GetHostLastHeard(gNetGame);
 		gNetBadge[0] = (dt > NET_BADGE_MS);
-		if (dt > NET_DROP_MS)
+		if (dt > NET_SILENCE_DROP_MS)
 			NetGameFatalError(kNetSequence_ErrorNoResponseFromHost);
 	}
 }
@@ -597,7 +616,7 @@ void Net_MaybeSendKeepAlive(void)
 }
 
 // CMR7 Stage 4: reset every per-connection liveness clock to now. Called at game-loop entry so the
-// long lobby/vehicle-select/level-load gap (which can exceed NET_DROP_MS) can never trip a false drop.
+// long lobby/vehicle-select/level-load gap can never trip a false drop on game-loop entry.
 void Net_RefreshLastHeard(void)
 {
 	if (!gNetGameInProgress || gNetGame == nil)
@@ -689,9 +708,32 @@ void EndNetworkGame(void)
 
 #pragma mark - Net sequence
 
+static void SetJoinDeniedReason(const NSpJoinDeniedMessage* denied)
+{
+	size_t out = 0;
+
+	for (size_t in = 0;
+		in < sizeof(denied->reason) && denied->reason[in] != '\0' && out + 1 < sizeof(gNetJoinDeniedReason);
+		in++)
+	{
+		unsigned char c = (unsigned char) denied->reason[in];
+		if (c >= 0x20 && c <= 0x7e)
+			gNetJoinDeniedReason[out++] = (char) c;
+	}
+
+	gNetJoinDeniedReason[out] = '\0';
+	if (out == 0)
+		SDL_strlcpy(gNetJoinDeniedReason, "THE HOST DENIED THE JOIN REQUEST.", sizeof(gNetJoinDeniedReason));
+}
+
+const char* Net_GetJoinDeniedReason(void)
+{
+	return gNetJoinDeniedReason;
+}
+
 /****************** NETWORK SEQUENCE *********************/
 
-bool UpdateNetSequence(void)
+static bool UpdateNetSequenceOnce(Boolean runFrameTicks)
 {
 	NSpMessageHeader* message = NULL;
 
@@ -699,13 +741,14 @@ bool UpdateNetSequence(void)
 	{
 		case kNetSequence_HostLobbyOpen:
 		{
-			if (kNSpRC_OK != NSpGame_AdvertiseTick(gNetGame, gFramesPerSecondFrac))
+			if (runFrameTicks && kNSpRC_OK != NSpGame_AdvertiseTick(gNetGame, gFramesPerSecondFrac))
 			{
 				gNetSequenceState = kNetSequence_Error;
 				break;
 			}
 
-			NSpGame_AcceptNewClient(gNetGame);
+			if (runFrameTicks)
+				NSpGame_AcceptNewClient(gNetGame);
 
 			message = NSpMessage_Get(gNetGame);
 
@@ -727,6 +770,8 @@ bool UpdateNetSequence(void)
 		}
 
 		case kNetSequence_HostReadyToStartGame:
+			if (!runFrameTicks)
+				break;
 			NSpGame_StopAdvertising(gNetGame);
 			NSpGame_StopAcceptingNewClients(gNetGame);
 			SetNetworkDiscoveryMode(false);
@@ -741,6 +786,8 @@ bool UpdateNetSequence(void)
 			break;
 
 		case kNetSequence_ClientSearchingForGames:
+			if (!runFrameTicks)
+				break;
 			if (kNSpRC_OK != NSpSearch_Tick(gNetSearch))
 			{
 				gNetSequenceState = kNetSequence_Error;
@@ -752,6 +799,8 @@ bool UpdateNetSequence(void)
 			break;
 
 		case kNetSequence_ClientFoundGames:
+			if (!runFrameTicks)
+				break;
 			if (kNSpRC_OK != NSpSearch_Tick(gNetSearch))
 			{
 				gNetSequenceState = kNetSequence_Error;
@@ -803,6 +852,12 @@ bool UpdateNetSequence(void)
 					printf("Join approved! My player ID is %d\n", approvedMessage->header.to);
 					break;
 				}
+
+				case	kNSpJoinDenied:
+					SetJoinDeniedReason((const NSpJoinDeniedMessage*) message);
+					gNetSequenceState = kNetSequence_ClientOfflineBecauseJoinDenied;
+					EndNetworkGame();
+					break;
 
 				case	kNSpPlayerLeft:												// see if someone decided to un-join
 //					ShowNamesOfJoinedPlayers();
@@ -945,6 +1000,21 @@ bool UpdateNetSequence(void)
 	}
 }
 
+bool UpdateNetSequence(void)
+{
+	bool gotAnyMessage = false;
+
+	for (int i = 0; i < NET_SEQUENCE_MESSAGE_BUDGET; i++)
+	{
+		bool gotMessage = UpdateNetSequenceOnce(i == 0);
+		if (!gotMessage)
+			break;
+		gotAnyMessage = true;
+	}
+
+	return gotAnyMessage;
+}
+
 
 #pragma mark - Host/Join
 
@@ -1033,6 +1103,7 @@ failure:
 Boolean SetupNetworkJoin(void)
 {
 	ResetNetGameTransientState();			// start from a clean slate
+	SDL_strlcpy(gNetJoinDeniedReason, "THE HOST DENIED THE JOIN REQUEST.", sizeof(gNetJoinDeniedReason));
 	SetNetworkDiscoveryMode(true);
 	SetNetworkPowerMode(true);
 
@@ -2175,6 +2246,7 @@ Boolean HandleOtherNetMessage(NSpMessageHeader	*message)
 					/* A PLAYER UNEXPECTEDLY HAS LEFT THE GAME */
 
 		case	kNSpPlayerLeft:
+				ForgetPlayerSync(((NSpPlayerLeftMessage*) message)->playerID);
 				if (gNetSequenceState == kNetSequence_GameLoop)
 				{
 					// CMR7 Stage 4 (G3): a running sim must convert frame-aligned, not at TCP-arrival time.

--- a/Source/Network/NetLow.c
+++ b/Source/Network/NetLow.c
@@ -994,16 +994,16 @@ static NSpMessageHeader* NSpMessage_GetAsClient(NSpGame* game)
 	{
 		case kNSpJoinApproved:
 		{
-			game->myID = message->to;		// that's our ID
-
-			NSpPlayer* newPlayer = NSpGame_GetPlayerFromID(game, game->myID);
+			NSpPlayerID approvedID = message->to;
+			NSpPlayer* newPlayer = NSpGame_GetPlayerFromID(game, approvedID);
 			if (!newPlayer)					// host supplied an out-of-range id: ignore rather than assert-crash
 			{
-				printf("kNSpJoinApproved: invalid id %d from host; ignoring.\n", (int) game->myID);
+				printf("kNSpJoinApproved: invalid id %d from host; ignoring.\n", (int) approvedID);
 				break;
 			}
 
-			newPlayer->id			= game->myID;
+			game->myID				= approvedID;
+			newPlayer->id			= approvedID;
 			newPlayer->state		= kNSpPlayerState_Me;
 			newPlayer->sockfd		= INVALID_SOCKET;		// client has no connection to itself
 			snprintf(newPlayer->name, sizeof(newPlayer->name), "YOU");		// TODO: get actual name
@@ -1119,8 +1119,9 @@ int NSpGame_AckJoinRequest(NSpGameReference gameRef, NSpMessageHeader* message)
 	{
 		NSpPlayer* player = &game->players[i];
 
-		if (player->state == kNSpPlayerState_Offline		// skip over dead clients
-			|| player->id == newPlayerID)					// skip over itself
+		if ((player->state != kNSpPlayerState_Me
+				&& player->state != kNSpPlayerState_ConnectedPeer)	// don't advertise half-handshaken peers
+			|| player->id == newPlayerID)						// skip over itself
 		{
 			continue;
 		}
@@ -1614,7 +1615,8 @@ uint32_t NSpGame_GetActivePlayersIDMask(NSpGameReference gameRef)
 		{
 			case kNSpPlayerState_Me:
 			case kNSpPlayerState_ConnectedPeer:
-				mask |= 1 << game->players[i].id;
+				if (NSpGame_IsValidPlayerID(gameRef, game->players[i].id))
+					mask |= 1u << (uint32_t) game->players[i].id;
 				break;
 
 			default:
@@ -2371,8 +2373,8 @@ uint32_t NSpGame_GetHostLastHeard(NSpGameReference gameRef)
 }
 
 // CMR7 Stage 4: refresh every liveness clock to now. Called at game-loop entry so the long
-// (possibly >NET_DROP_MS) lobby/vehicle-select/level-load gap can never trip a false drop on the
-// first in-game NetCheck_ConnectionTimeouts.
+// Lobby/vehicle-select/level-load gaps can be long, so refresh the clocks before the first
+// in-game NetCheck_ConnectionTimeouts instead of treating setup time as connection silence.
 void NSpGame_TouchAllLastHeard(NSpGameReference gameRef)
 {
 	NSpGame* game = NSpGame_Unbox(gameRef);

--- a/Source/Network/NetValidation.c
+++ b/Source/Network/NetValidation.c
@@ -48,6 +48,8 @@ Boolean NetValidateInboundEnvelope(NetInboundRole role, const NSpMessageHeader* 
 	switch (message->what)
 	{
 		case kNSpJoinApproved:
+			return message->to > kNSpHostID
+				&& message->to < kNSpHostID + MAX_CLIENTS;
 		case kNSpPlayerJoined:
 		case kNSpPlayerLeft:
 		case kNetConfigureMessage:
@@ -68,18 +70,45 @@ Boolean NetValidateInboundEnvelope(NetInboundRole role, const NSpMessageHeader* 
 
 Boolean NetValidateConfigPayload(const NetConfigMessage* message)
 {
-	return message->gameMode >= GAME_MODE_MULTIPLAYERRACE
-		&& message->gameMode <= GAME_MODE_CAPTUREFLAG
-		&& message->age >= 0
+	if (message->gameMode < GAME_MODE_MULTIPLAYERRACE
+		|| message->gameMode > GAME_MODE_CAPTUREFLAG
+		|| message->trackNum < 0
+		|| message->trackNum >= NUM_TRACKS)
+	{
+		return false;
+	}
+
+	// Race tracks and battle arenas have different data contracts. In particular,
+	// scoreboard storage only has NUM_RACE_TRACKS rows, so never accept a race that
+	// names a battle arena. Conversely, battle modes require an arena.
+	if (message->gameMode == GAME_MODE_MULTIPLAYERRACE)
+	{
+		if (message->trackNum >= NUM_RACE_TRACKS)
+			return false;
+	}
+	else if (message->trackNum < NUM_RACE_TRACKS)
+	{
+		return false;
+	}
+
+	return message->age >= 0
 		&& message->age < NUM_AGES
-		&& message->trackNum >= 0
-		&& message->trackNum < NUM_TRACKS
 		&& message->numPlayers >= 1
 		&& message->numPlayers <= MAX_LOCAL_PLAYERS
 		&& message->playerNum >= 0
 		&& message->playerNum < message->numPlayers
 		&& message->difficulty < NUM_DIFFICULTIES
 		&& message->targetFPS <= MAX_GAME_FPS;
+}
+
+uint32_t NetRetainActiveSyncBits(uint32_t syncedMask, uint32_t activeMask)
+{
+	return syncedMask & activeMask;
+}
+
+Boolean NetAreAllActivePlayersSynced(uint32_t syncedMask, uint32_t activeMask)
+{
+	return NetRetainActiveSyncBits(syncedMask, activeMask) == activeMask;
 }
 
 Boolean NetValidatePlayerCharPayload(const NetPlayerCharTypeMessage* message, int expectedPlayer, int numRealPlayers)

--- a/Source/Player/Player.c
+++ b/Source/Player/Player.c
@@ -619,6 +619,8 @@ OGLVector2D	aimVec, toVec;
 void ChooseTaggedPlayer(void)
 {
 short	i,j;
+	for (int p = 0; p < gNumTotalPlayers; p++)
+		gPlayerInfo[p].isIt = false;
 
 	i = j = RandomRange(0, gNumTotalPlayers-1);
 
@@ -760,7 +762,6 @@ ObjNode *obj;
 		obj = obj->ChainNode;
 	}
 }
-
 
 
 

--- a/Source/Player/Player_Car.c
+++ b/Source/Player/Player_Car.c
@@ -1831,6 +1831,8 @@ short		p2 = car2->PlayerNum;
 		case	GAME_MODE_TAG2:
 				if (!gTrackCompleted)
 				{
+					if (gPlayerInfo[p1].isEliminated || gPlayerInfo[p2].isEliminated)
+						break;
 
 						/* CAR 1 WAS IT */
 
@@ -3224,10 +3226,10 @@ ObjNode	*obj;
 				PlayerLoseHealth(i, d2 / BLAST_DAMAGE);
 			}
 
-				/* CAUSE DROP TORCH */
+				/* CAUSE DROP FLAG */
 
 			else
-			if (gGameMode == GAME_MODE_SURVIVAL)
+			if (gGameMode == GAME_MODE_CAPTUREFLAG)
 				PlayerDropFlag(obj);
 
 
@@ -3599,7 +3601,6 @@ new_group:
 
 
 }
-
 
 
 

--- a/Source/Screens/NetGather.c
+++ b/Source/Screens/NetGather.c
@@ -102,6 +102,10 @@ static void UpdateNetGatherPrompt(void)
 			output = Localize(STR_YOU_WERE_KICKED);
 			break;
 
+		case kNetSequence_ClientOfflineBecauseJoinDenied:
+			output = Net_GetJoinDeniedReason();
+			break;
+
 		case kNetSequence_OfflineEverybodyLeft:
 			output = Localize(STR_EVERYBODY_LEFT);
 			break;
@@ -307,4 +311,3 @@ static int DoNetGatherControls(void)
 
 	return 0;
 }
-

--- a/Source/Screens/RaceTimes.c
+++ b/Source/Screens/RaceTimes.c
@@ -132,6 +132,14 @@ static Boolean IsNewRecord(int track, int rank)
 // Returns new rank, or negative value if not rankable
 int SaveRaceTime(int playerNum)
 {
+	// Scoreboard storage has rows for race tracks only. Network configuration validation
+	// enforces this too, but keep the persistence boundary safe if a caller ever installs
+	// an invalid track through a command line, custom asset, or future code path.
+	if ((unsigned int) gTrackNum >= NUM_RACE_TRACKS)
+	{
+		return -1;
+	}
+
 	const PlayerInfoType* pi = &gPlayerInfo[playerNum];
 	float raceTime = GetRaceTime(playerNum);
 	ScoreboardRecord* trackRecords = gScoreboard.records[gTrackNum];

--- a/Source/System/File.c
+++ b/Source/System/File.c
@@ -1069,6 +1069,8 @@ Ptr						tempBuffer16 = nil;
 	gNumPaths              	= (**header).numPaths;
 	gNumCheckpoints			= (**header).numCheckpoints;
 	ReleaseResource(hand);
+	if (gNumCheckpoints < 0 || gNumCheckpoints > MAX_CHECKPOINTS)
+		DoFatalAlert("ReadDataFromPlayfieldFile: invalid checkpoint count %ld", gNumCheckpoints);
 
 	if ((gTerrainTileWidth % SUPERTILE_SIZE) != 0)		// terrain must be non-fractional number of supertiles in w/h
 		DoFatalAlert("ReadDataFromPlayfieldFile: terrain width not a supertile multiple");
@@ -1433,9 +1435,6 @@ Ptr						tempBuffer16 = nil;
 
 	if (gNumCheckpoints > 0)
 	{
-		if (gNumCheckpoints > MAX_CHECKPOINTS)
-			DoFatalAlert("ReadDataFromPlayfieldFile: gNumCheckpoints > MAX_CHECKPOINTS");
-
 				/* READ CHECKPOINT LIST */
 
 		hand = GetResource('CkPt',1000);
@@ -1443,8 +1442,19 @@ Ptr						tempBuffer16 = nil;
 		{
 			DetachResource(hand);
 			HLock(hand);
+			const Size expectedCheckpointBytes = (Size) gNumCheckpoints * sizeof(CheckpointDefType);
+			const Size checkpointResourceBytes = GetHandleSize(hand);
+			if (checkpointResourceBytes != expectedCheckpointBytes)
+			{
+				ReleaseResource(hand);
+				DoFatalAlert(
+					"ReadDataFromPlayfieldFile: CkPt resource size mismatch (got %d, expected %d)",
+					(int) checkpointResourceBytes,
+					(int) expectedCheckpointBytes);
+				return;
+			}
 			UNPACK_STRUCTS_HANDLE(">HH2f2f", CheckpointDefType, gNumCheckpoints, hand);
-			BlockMove(*hand, &gCheckpointList[0], GetHandleSize(hand));
+			BlockMove(*hand, &gCheckpointList[0], expectedCheckpointBytes);
 			ReleaseResource(hand);
 
 						/* CONVERT COORDINATES */

--- a/Source/System/Input.c
+++ b/Source/System/Input.c
@@ -58,11 +58,6 @@ static SDL_Gamepad *TryOpenAnyUnusedGamepad(bool showMessage);
 static int GetGamepadSlotFromJoystick(SDL_JoystickID joystickID);
 static void CloseGamepad(int gamepadSlot);
 
-// Touch Controls (enabled on all platforms, hidden until touch event)
-#if defined(__ANDROID__) || (defined(__IOS__) && !defined(__TVOS__))
-static SDL_Sensor *gAccelerometer = NULL;
-#endif
-
 // Touch Debugging
 #define TOUCH_DEBUG_LINES 0
 
@@ -246,27 +241,6 @@ static void EnableVirtualJoystick(void) {
     SDL_Log("Failed to add Virtual Gamepad: %s", SDL_GetError());
   }
 }
-
-#if defined(__ANDROID__) || (defined(__IOS__) && !defined(__TVOS__))
-static void InitMobileInput(void) {
-  InitTouchData();
-
-  if (!gAccelerometer) {
-    int num_sensors = 0;
-    SDL_SensorID *sensorIDs = SDL_GetSensors(&num_sensors);
-    if (sensorIDs) {
-      for (int i = 0; i < num_sensors; ++i) {
-        if (SDL_GetSensorTypeForID(sensorIDs[i]) == SDL_SENSOR_ACCEL) {
-          gAccelerometer = SDL_OpenSensor(sensorIDs[i]);
-          if (gAccelerometer)
-            break;
-        }
-      }
-      SDL_free(sensorIDs);
-    }
-  }
-}
-#endif
 
 void ValidateActiveFingers(void) {
     int num_touch_devices = 0;
@@ -711,9 +685,6 @@ void DoSDLMaintenance(void) {
 
   // Initialize touch input data (but don't create joystick yet on desktop)
   InitTouchData();
-#if defined(__ANDROID__) || (defined(__IOS__) && !defined(__TVOS__))
-  InitMobileInput();
-#endif
 
   /**********************/
   /* DO SDL MAINTENANCE */
@@ -748,7 +719,7 @@ void DoSDLMaintenance(void) {
     case SDL_EVENT_FINGER_MOTION: {
 #if !defined(__TVOS__)
       // Only activate touch controls from real touch events (not mouse-simulated)
-      if (event.tfinger.touchID == SDL_TOUCH_MOUSEID) break;
+      if (event.tfinger.touchID == SDL_MOUSE_TOUCHID) break;
 
       if (!gTouchControlsActive) {
          EnableVirtualJoystick(); // Lazy create

--- a/Source/System/Localization.c
+++ b/Source/System/Localization.c
@@ -7,7 +7,7 @@
 
 #define CSV_PATH ":System:strings.csv"
 
-#define MAX_STRINGS (NUM_LOCALIZED_STRINGS + 1)
+#define MAX_STRINGS NUM_LOCALIZED_STRINGS
 
 static GameLanguageID	gCurrentStringsLanguage = LANGUAGE_ILLEGAL;
 static Ptr				gStringsBuffer = nil;
@@ -67,10 +67,28 @@ void LoadLocalizedStrings(GameLanguageID languageID)
 
 		if (myPhrase != NULL)
 		{
+			if (row >= MAX_STRINGS)
+			{
+				DoFatalAlert(
+					"Too many rows in " CSV_PATH " (expected %d localized strings)",
+					NUM_LOCALIZED_STRINGS - 1);
+				return;
+			}
 			gStringsTable[row] = myPhrase;
 			row++;
 		}
 	}
+
+	if (row != MAX_STRINGS)
+	{
+		DoFatalAlert(
+			"Wrong number of rows in " CSV_PATH " (got %d, expected %d)",
+			row - 1,
+			NUM_LOCALIZED_STRINGS - 1);
+		return;
+	}
+
+	gCurrentStringsLanguage = languageID;
 }
 
 const char* Localize(LocStrID stringID)
@@ -130,4 +148,6 @@ void DisposeLocalizedStrings(void)
 		SafeDisposePtr(gStringsBuffer);
 		gStringsBuffer = nil;
 	}
+
+	gCurrentStringsLanguage = LANGUAGE_ILLEGAL;
 }

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -1637,8 +1637,10 @@ short	i,t,winner;
 
 				if (gPlayerInfo[gWhoIsIt].tagTimer <= 0.0f)					// if done, then eliminate this player from the battle
 				{
-					gPlayerInfo[gWhoIsIt].tagTimer = 0;
-					gPlayerInfo[gWhoIsIt].isEliminated = true;
+					const short eliminatedPlayer = gWhoIsIt;
+					gPlayerInfo[eliminatedPlayer].tagTimer = 0;
+					gPlayerInfo[eliminatedPlayer].isEliminated = true;
+					gPlayerInfo[eliminatedPlayer].isIt = false;
 
 					gNumPlayersEliminated++;
 					if (gNumPlayersEliminated == (gNumTotalPlayers-1))		// if all players eliminated except 1 then we're done!
@@ -1666,7 +1668,7 @@ short	i,t,winner;
 							/* ELIMINATE THIS PLAYER AND CHOOSE ANOTHER */
 					else
 					{
-						ShowWinLose(gWhoIsIt, 0, 0);						// this player is eliminated
+						ShowWinLose(eliminatedPlayer, 0, 0);					// this player is eliminated
 						ChooseTaggedPlayer();								// tagged guy is gone, so choose a new one
 					}
 

--- a/Tests/LocalizationDataTests.py
+++ b/Tests/LocalizationDataTests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import csv
+from pathlib import Path
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def main() -> None:
+    root = Path(sys.argv[1]).resolve()
+    header = (root / "Source/Headers/localization.h").read_text(encoding="utf-8")
+
+    try:
+        enum_body = header.split("typedef enum LocStrID", 1)[1].split(
+            "NUM_LOCALIZED_STRINGS", 1
+        )[0]
+    except IndexError:
+        fail("Could not find the LocStrID enum")
+
+    string_ids = re.findall(
+        r"^\s*STR_[A-Z0-9_]+(?:\s*=\s*[^,]+)?\s*,",
+        enum_body,
+        flags=re.MULTILINE,
+    )
+    if not string_ids or "STR_NULL" not in string_ids[0]:
+        fail("LocStrID must begin with STR_NULL")
+
+    with (root / "Data/System/strings.csv").open(
+        "r", encoding="utf-8-sig", newline=""
+    ) as strings_file:
+        localized_rows = sum(
+            1 for row in csv.reader(strings_file) if any(field for field in row)
+        )
+
+    expected_rows = len(string_ids) - 1  # STR_NULL has no CSV row.
+    if localized_rows != expected_rows:
+        fail(
+            "strings.csv has "
+            f"{localized_rows} localized rows, but LocStrID requires {expected_rows}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/ValidationTests.c
+++ b/Tests/ValidationTests.c
@@ -38,6 +38,18 @@ static void TestEnvelopeValidation(void)
 	NSpMessageHeader unknown = {.what = 'nope', .messageLen = sizeof(NSpMessageHeader)};
 	assert(!NetValidateInboundEnvelope(kNetInbound_Host, &unknown));
 	assert(!NetValidateInboundEnvelope(kNetInbound_Client, &unknown));
+
+	NSpJoinApprovedMessage approved = {0};
+	approved.header.what = kNSpJoinApproved;
+	approved.header.messageLen = sizeof(approved);
+	approved.header.to = kNSpHostID + MAX_CLIENTS - 1;
+	assert(NetValidateInboundEnvelope(kNetInbound_Client, &approved.header));
+	approved.header.to = kNSpHostID + MAX_CLIENTS;
+	assert(!NetValidateInboundEnvelope(kNetInbound_Client, &approved.header));
+	approved.header.to = kNSpHostID;
+	assert(!NetValidateInboundEnvelope(kNetInbound_Client, &approved.header));
+	approved.header.to = kNSpAllPlayers;
+	assert(!NetValidateInboundEnvelope(kNetInbound_Client, &approved.header));
 }
 
 static NetPlayerCharTypeMessage ValidCharMessage(void)
@@ -93,6 +105,27 @@ static void TestConfigValidation(void)
 	message.playerNum = 1;
 	message.trackNum = NUM_TRACKS;
 	assert(!NetValidateConfigPayload(&message));
+
+	message.trackNum = NUM_RACE_TRACKS;
+	assert(!NetValidateConfigPayload(&message));
+	message.gameMode = GAME_MODE_TAG1;
+	assert(NetValidateConfigPayload(&message));
+	message.trackNum = NUM_RACE_TRACKS - 1;
+	assert(!NetValidateConfigPayload(&message));
+	message.gameMode = GAME_MODE_CAPTUREFLAG;
+	message.trackNum = NUM_TRACKS - 1;
+	assert(NetValidateConfigPayload(&message));
+}
+
+static void TestSyncMaskValidation(void)
+{
+	const uint32_t hostAndClient1 = (1u << 0) | (1u << 1);
+	const uint32_t departedClient2 = 1u << 2;
+
+	assert(NetAreAllActivePlayersSynced(hostAndClient1, hostAndClient1));
+	assert(!NetAreAllActivePlayersSynced(1u << 0, hostAndClient1));
+	assert(NetAreAllActivePlayersSynced(hostAndClient1 | departedClient2, hostAndClient1));
+	assert(NetRetainActiveSyncBits(hostAndClient1 | departedClient2, hostAndClient1) == hostAndClient1);
 }
 
 static NetClientControlInfoMessageType ValidControlMessage(void)
@@ -485,6 +518,7 @@ int main(void)
 	TestEnvelopeValidation();
 	TestCharacterValidation();
 	TestConfigValidation();
+	TestSyncMaskValidation();
 	TestControlValidation();
 	TestHostControlValidation();
 	TestDeterministicEventMath();

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -14,7 +14,7 @@ The fork is in better shape than its provenance suggests: the core lockstep dete
 1. **Wire safety (security):** the host writes to arrays using attacker-controlled indices from network payloads — remotely exploitable memory corruption on any LAN. 2 critical, 4 high findings.
 2. **Session-killer netcode bugs:** never-reset state (queues, strike counter) makes the *second* hosted game in a process reliably die; lobby churn wedges races; several disconnect paths call `DoFatalAlert` and kill everyone.
 3. **Unintentional gameplay-fidelity regressions:** the RNG split into synced/unsynced streams (a2c3b97) misrouted ~8 *simulation-affecting* random draws to the unsynced per-machine stream — traps, land mine, oil slick, stump geometry, sub AI — creating real cross-peer divergence the rubber-band only partially masks. Plus one new behavior (cactus car-spin) that contradicts the fork's own legacy-restoration intent.
-4. **WiFi stutter root cause:** the per-frame blocking lockstep barrier converts any single client's radio jitter into a global freeze, and the 30-frame pre-roll buys jitter absorption at a constant ~500ms input lag. The fix is not tuning — it's removing the barrier. A complete, judge-vetted redesign ("CMR7 rev B") is in §5 and `wifi-design-synthesis.md`, estimated 20–30 dev-days, staged so each stage ships independently.
+4. **WiFi stutter root cause:** the per-frame blocking lockstep barrier converts any single client's radio jitter into a global freeze, and the 30-frame pre-roll buys jitter absorption at a constant ~500ms input lag. The fix is not tuning — it's removing the barrier. A complete, judge-vetted redesign ("CMR7 rev B") is in §5 and the [CMR7 staged implementation plan](WIFI-NETCODE-CMR7.md#staged-implementation-plan), estimated 20–30 dev-days, staged so each stage ships independently.
 
 A handful of changes are **intentional tuning you should explicitly ratify or revert** (§4.3): WATER_FRICTION 1600→1000, ice acceleration 0.3→0.5, the PCG32 RNG swap, and the cactus car-spin.
 
@@ -128,7 +128,7 @@ Current model: single-threaded TCP lockstep where the **client busy-blocks at to
 
 So the stutter is architectural, not parametric. No tuning of the current barrier makes WiFi smooth.
 
-### The design (unanimous judge verdict; full spec in `wifi-design-synthesis.md`)
+### The design (unanimous judge verdict; [full protocol specification](WIFI-NETCODE-CMR7.md#protocol-specification))
 
 **CMR7 rev B — "Free-Running Lockstep":** keep TCP, keep the star topology, keep variable timestep and the fatal seed check — but **the host never waits**. Three mechanisms:
 
@@ -217,8 +217,8 @@ Acceptance profile: mixed LAN with one congested-2.4GHz peer — wired client fr
 
 ### Companion documents
 
-- `WIFI-NETCODE-CMR7.md` — the full CMR7 rev B WiFi redesign: protocol, message formats, latency math, mixed-LAN handling, fidelity analysis, and the staged implementation plan.
-- `SUBMODULE-AUDIT.md` — audit of the forked `extern/Pomme` and `extern/gl4es` submodules vs upstream.
+- [WIFI-NETCODE-CMR7.md](WIFI-NETCODE-CMR7.md#overview) — the full CMR7 rev B WiFi redesign: protocol, message formats, latency math, mixed-LAN handling, fidelity analysis, and the staged implementation plan.
+- [SUBMODULE-AUDIT.md](SUBMODULE-AUDIT.md) — audit of the forked `extern/Pomme` and `extern/gl4es` submodules vs upstream.
 
 Most of the P0/P1 findings in this review are **already fixed** on this branch (see the
 commit history); the items explicitly deferred to "CMR7 Stage 0" are tracked in the WiFi


### PR DESCRIPTION
## Summary

Follow-up fixes for the validated findings from the holistic review:

- harden network configuration, join IDs, sync barriers, half-joined peers, lobby draining, join-denial reporting, and deterministic disconnect handling
- replace the unachievable 30-second background grace with an explicit 5-second lockstep stall policy
- bound checkpoint/localization data and add localization-data regression coverage
- prevent Tag re-elimination and restore Capture-the-Flag blast drops
- correct SDL mouse-touch filtering, remove unused sensor enumeration, normalize Android asset paths, and fail fast on unstaged Gradle package inputs
- require non-empty CTest discovery and add Linux ARM64, DEB/RPM, iOS, and tvOS PR coverage
- repair stale WiFi-design documentation links

The Android process-reuse claim was not changed because validation showed SDL activity recreation is disabled in this build; its process-lifetime statics are not reachable through the claimed second-session path.

## Validation

- full GCC desktop build
- CTest: 5/5 passed, including the new localization-data check
- focused ASan/UBSan validation
- Clang syntax/warning audit of modified network code
- all shipped terrain checkpoint resources verified against their declared counts
- Android ARM64 native build and `assembleDebug` with `/opt/android-ndk` r29
- Android `lintDebug`
- isolated clean-checkout Gradle fail-fast test
- DEB and RPM CPack generation
- strict YAML, shell syntax, Python, and whitespace checks
